### PR TITLE
CVE-2025-58057 unbounded memory allocation in Netty's BrotliDecoder allows OOM via zip-bomb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <jetty.version>11.0.25</jetty.version>
         <grizzly-framework.version>3.0.1</grizzly-framework.version>
         <servlet-api.version>5.0.0</servlet-api.version>
-        <cassandra.version>4.19.2</cassandra.version>
+        <cassandra.version>4.19.2</cassandra.version><!--after version update, check netty version-->
         <cassandra-all.version>5.0.7</cassandra-all.version>
     </properties>
 
@@ -941,6 +941,13 @@
                         <artifactId>lz4-java</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.132.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
replaces OpenIdentityPlatform/OpenDJ#636