### PR TITLE
Fix field projection collapsing nested JsonPointers to leaf names

### DIFF
--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Resources.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Resources.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -28,7 +29,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import org.forgerock.api.annotations.CollectionProvider;
 import org.forgerock.api.annotations.Path;
@@ -99,6 +99,15 @@ public final class Resources {
      * <b>NOTE:</b> this method only performs a shallow copy of extracted
      * fields, so changes to the filtered JSON value may impact the original
      * JSON value, and vice-versa.
+     * <p>
+     * The projection preserves the nested structure of the requested fields:
+     * each requested {@link JsonPointer} is written back under its full path
+     * rather than being collapsed to its leaf name. As a result, leaf fields
+     * that share the same name at different levels of nesting do not conflict.
+     * For example, projecting {@code userName} and {@code manager/userName}
+     * over <code>{ "userName": "bjensen", "manager": { "userName": "jdoe" } }</code>
+     * yields <code>{ "userName": "bjensen", "manager": { "userName": "jdoe" } }</code>,
+     * i.e. the top-level {@code userName} is not overwritten by the nested one.
      *
      * @param resource
      *            The JSON value whose fields are to be filtered.
@@ -111,21 +120,24 @@ public final class Resources {
         if (fields.isEmpty() || resource.isNull() || resource.size() == 0) {
             return resource;
         } else {
-            final Map<String, Object> filtered = new LinkedHashMap<>(fields.size());
+            final JsonValue filtered = new JsonValue(new LinkedHashMap<String, Object>(fields.size()));
             for (final JsonPointer field : fields) {
                 if (field.isEmpty()) {
                     // Special case - copy resource fields (assumes Map).
-                    filtered.putAll(resource.asMap());
+                    filtered.asMap().putAll(resource.asMap());
                 } else {
-                    // FIXME: what should we do if the field refers to an array element?
                     final JsonValue value = resource.get(field);
                     if (value != null) {
-                        final String key = field.leaf();
-                        filtered.put(key, value.getObject());
+                        // Preserve the nested structure of the requested field
+                        // instead of collapsing it to its leaf name. This keeps
+                        // same-named leaf fields at different levels of nesting
+                        // (e.g. "userName" and "manager/userName") from
+                        // overwriting each other.
+                        filtered.putPermissive(field, value.getObject());
                     }
                 }
             }
-            return new JsonValue(filtered);
+            return filtered;
         }
     }
 

--- a/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/ResourcesTest.java
+++ b/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/ResourcesTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -161,25 +162,36 @@ public final class ResourcesTest {
             {
                     filter("/a/b"),
                     content(object(field("a", object(field("b", "1"), field("c", "2"))), field("d", "3"))),
-                    expected(object(field("b", "1")))
+                    expected(object(field("a", object(field("b", "1")))))
             },
 
             {
                     filter("/a/b", "/d"),
                     content(object(field("a", object(field("b", "1"), field("c", "2"))), field("d", "3"))),
-                    expected(object(field("b", "1"), field("d", "3")))
+                    expected(object(field("a", object(field("b", "1"))), field("d", "3")))
             },
 
             {
                     filter("/a/b", "/a"),
                     content(object(field("a", object(field("b", "1"), field("c", "2"))), field("d", "3"))),
-                    expected(object(field("b", "1"), field("a", object(field("b", "1"), field("c", "2")))))
+                    expected(object(field("a", object(field("b", "1"), field("c", "2")))))
             },
 
             {
                     filter("/a", "/a/b"),
                     content(object(field("a", object(field("b", "1"), field("c", "2"))), field("d", "3"))),
-                    expected(object(field("a", object(field("b", "1"), field("c", "2"))), field("b", "1")))
+                    expected(object(field("a", object(field("b", "1"), field("c", "2")))))
+            },
+
+            // Same-named leaf fields at different levels of nesting must coexist
+            // (see OpenIDM discussion #183): the top-level "userName" must not be
+            // overwritten by the nested "manager/userName".
+            {
+                    filter("/userName", "/manager", "/manager/userName"),
+                    content(object(field("userName", "bjensen"),
+                            field("manager", object(field("userName", "jdoe"))))),
+                    expected(object(field("userName", "bjensen"),
+                            field("manager", object(field("userName", "jdoe")))))
             },
 
         };
@@ -190,6 +202,23 @@ public final class ResourcesTest {
     public void testFilter(List<JsonPointer> filter, JsonValue content, JsonValue expected) {
         Assertions.assertThat(Resources.filterResource(content, filter).getObject()).isEqualTo(
                 expected.getObject());
+    }
+
+    @Test
+    public void testFilterPreservesNestedFieldsWithCollidingLeafNames() {
+        // Given a resource with a "userName" both at the top level and nested
+        // inside "manager" (see OpenIDM discussion #183).
+        final JsonValue content = content(object(
+                field("userName", "bjensen"),
+                field("manager", object(field("userName", "jdoe")))));
+
+        // When projecting userName, manager and manager/userName.
+        final JsonValue result = Resources.filterResource(content,
+                filter("/userName", "/manager", "/manager/userName"));
+
+        // Then the nested structure is preserved and the leaf names do not collide.
+        assertThat(result.get("userName").asString()).isEqualTo("bjensen");
+        assertThat(result.get("manager").get("userName").asString()).isEqualTo("jdoe");
     }
 
     @DataProvider


### PR DESCRIPTION
## Summary

`Resources.filterResource(JsonValue, Collection<JsonPointer>)` built the
projected result using `field.leaf()` as a flat key:

```java
final String key = field.leaf();
filtered.put(key, value.getObject());
```

As a result, a nested pointer (e.g. `manager/userName`) lost its nesting and
was stored under the leaf name (`userName`), overwriting the same-named
top-level field. With `_fields=userName,manager,manager/userName`, the
top-level `userName` was replaced by the value of `manager/userName`.

This affected any `RequestHandler` that does not set the response fields
explicitly (e.g. custom scripted OpenIDM endpoints), because the projection is
performed in `InternalConnection` via
`Resources.filterResource(response, request.getFields())`.

## Changes

- **`Resources.filterResource(JsonValue, Collection<JsonPointer>)`** now uses
  `JsonValue.putPermissive(field, value)` so each requested `JsonPointer` is
  written back under its full path, preserving nesting. Missing parent objects
  are created on demand, and same-named leaf fields at different nesting levels
  no longer collide.
  - The empty pointer (`field.isEmpty()`) still copies all resource fields.
  - Shallow-copy semantics are preserved (`value.getObject()`).
  - Unresolved pointers (including array-index pointers that do not resolve)
    are skipped, so there is no regression for that case.
- **Javadoc** updated to document that the projection preserves the nested
  structure of the requested fields and that same-named leaf fields at
  different levels do not conflict.
- **Tests** in `ResourcesTest`:
  - Updated `testFilterData` rows that encoded the old flat behavior to the
    correct nested structure.
  - Added a dedicated test
    (`testFilterPreservesNestedFieldsWithCollidingLeafNames`) and a data row
    covering the leaf-name collision:
    `fields = [userName, manager, manager/userName]` over
    `{ userName: "bjensen", manager: { userName: "jdoe" } }`
    must yield `result.userName == "bjensen"` and
    `result.manager.userName == "jdoe"`.

## Behavior

Before:

```json
{ "userName": "jdoe", "manager": { "userName": "jdoe" } }
```

After:

```json
{ "userName": "bjensen", "manager": { "userName": "jdoe" } }
```

## Testing

`mvn -o test -Dtest=ResourcesTest` in `commons/rest/json-resource` — all 106
tests pass.

## Related

Once an updated commons `3.1.1-SNAPSHOT` is published, the OpenIDM test
`openidm-script/.../CustomEndpointFieldProjectionTest` will pass.

See OpenIDM discussion:
https://github.com/OpenIdentityPlatform/OpenIDM/discussions/183

