### PR TITLE
Migrate tests from Mockito 1 (mockito-all) to Mockito 2 (mockito-core)

### DIFF
--- a/bloomfilter/core/src/test/java/org/forgerock/bloomfilter/GeometricSeriesBloomFilterPoolTest.java
+++ b/bloomfilter/core/src/test/java/org/forgerock/bloomfilter/GeometricSeriesBloomFilterPoolTest.java
@@ -12,14 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.bloomfilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyDouble;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/commons/audit/handler-elasticsearch/src/test/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandlerTest.java
+++ b/commons/audit/handler-elasticsearch/src/test/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandlerTest.java
@@ -23,7 +23,7 @@ import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.util.promise.Promises.newResultPromise;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/commons/audit/handler-jms/pom.xml
+++ b/commons/audit/handler-jms/pom.xml
@@ -13,7 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2016 ForgeRock AS.
-  ~ Portions copyright 2020-2025 3A Systems, LLC
+  ~ Portions copyright 2020-2026 3A Systems, LLC
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -87,8 +87,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons/audit/handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerTest.java
+++ b/commons/audit/handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerTest.java
@@ -22,8 +22,8 @@ import static org.forgerock.audit.AuditServiceBuilder.newAuditService;
 import static org.forgerock.audit.json.AuditJsonConfig.parseAuditEventHandlerConfiguration;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
@@ -162,7 +162,7 @@ public class JmsAuditEventHandlerTest {
                 Thread.sleep(100L); // small delay to simulate time to send message.
                 logger.info("message sent by session {}: {}",
                         sessionCount,
-                        invocation.getArgumentAt(0, TextMessage.class).getText());
+                        invocation.<TextMessage>getArgument(0).getText());
                 return null;
             }
         }).when(producer).send(textMessage);

--- a/commons/audit/handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JndiJmsContextManagerTest.java
+++ b/commons/audit/handler-jms/src/test/java/org/forgerock/audit/handlers/jms/JndiJmsContextManagerTest.java
@@ -12,13 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.audit.handlers.jms;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import jakarta.jms.ConnectionFactory;
@@ -82,15 +82,18 @@ public class JndiJmsContextManagerTest {
         InitialContextFactoryBuilder builder = mock(InitialContextFactoryBuilder.class);
         setInitialContextFactoryBuilder(builder);
         ClassLoader contextClassLoader = mock(ClassLoader.class);
-        Thread.currentThread().setContextClassLoader(contextClassLoader);
         Context context = mock(Context.class);
         InitialContextFactory initialContextFactory = mock(InitialContextFactory.class);
-        when(initialContextFactory.getInitialContext(any(Hashtable.class))).thenReturn(context);
-        when(builder.createInitialContextFactory(any(Hashtable.class))).thenReturn(initialContextFactory);
 
         // Setup JMS specific components for this test.
         ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
         Topic topic = mock(Topic.class);
+
+        // Swap the thread context classloader to the mock only after all mocks have been created, so that
+        // Mockito's (byte-buddy) mock generation resolves classes against the real classloader.
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+        when(initialContextFactory.getInitialContext(any(Hashtable.class))).thenReturn(context);
+        when(builder.createInitialContextFactory(any(Hashtable.class))).thenReturn(initialContextFactory);
         JndiConfiguration configuration = new JndiConfiguration();
         configuration.setJmsConnectionFactoryName("ConnectionFactory");
         configuration.setJmsTopicName("audit");

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/pom.xml
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/pom.xml
@@ -13,7 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2013-2016 ForgeRock AS.
-* Portions copyright 2020-2025 3A Systems LLC.
+* Portions copyright 2020-2026 3A Systems LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -78,8 +78,7 @@
         
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/test/java/org/forgerock/caf/http/CookieTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/test/java/org/forgerock/caf/http/CookieTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.http;
@@ -20,7 +20,7 @@ package org.forgerock.caf.http;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -70,7 +70,7 @@ public class CookieTest {
         addCookie(cookie, response);
 
         //Then
-        verify(response, never()).addCookie(Matchers.anyObject());
+        verify(response, never()).addCookie(ArgumentMatchers.anyObject());
         ArgumentCaptor<String> cookieCaptor = ArgumentCaptor.forClass(String.class);
         verify(response).addHeader(eq("Set-Cookie"), cookieCaptor.capture());
         assertThat(cookieCaptor.getValue()).contains("COOKIE_NAME=COOKIE_VALUE;",

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/test/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModuleTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/test/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModuleTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.jaspi.modules.session.jwt;
@@ -64,7 +64,7 @@ import org.forgerock.json.jose.jwt.Jwt;
 import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.util.encode.Base64;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -603,7 +603,7 @@ public class ServletJwtSessionModuleTest {
 
         //Then
         assertEquals(authStatus, AuthStatus.SUCCESS);
-        verify(claimsSet).setIssuedAtTime(Matchers.<Date>anyObject());
+        verify(claimsSet).setIssuedAtTime(ArgumentMatchers.<Date>anyObject());
         ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
         verify(response).addCookie(cookieCaptor.capture());
         Cookie newCookie = cookieCaptor.getValue();
@@ -709,17 +709,17 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
@@ -798,17 +798,17 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
@@ -926,17 +926,17 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
@@ -1015,17 +1015,17 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claims(anyMapOf(String.class, Object.class))).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);
@@ -1103,17 +1103,17 @@ public class ServletJwtSessionModuleTest {
         JwtClaimsSetBuilder jwtClaimsSetBuilder = mock(JwtClaimsSetBuilder.class);
         JwtClaimsSet claimsSet = mock(JwtClaimsSet.class);
 
-        given(jwtBuilderFactory.jwe(Matchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
+        given(jwtBuilderFactory.jwe(ArgumentMatchers.<Key>anyObject())).willReturn(encryptedJwtBuilder);
         given(encryptedJwtBuilder.headers()).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.alg(Matchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
-        given(jweHeaderBuilder.enc(Matchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.alg(ArgumentMatchers.<Algorithm>anyObject())).willReturn(jweHeaderBuilder);
+        given(jweHeaderBuilder.enc(ArgumentMatchers.<EncryptionMethod>anyObject())).willReturn(jweHeaderBuilder);
         given(jweHeaderBuilder.done()).willReturn(encryptedJwtBuilder);
 
         given(jwtBuilderFactory.claims()).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.jti(anyString())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.exp(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.nbf(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
-        given(jwtClaimsSetBuilder.iat(Matchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.exp(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.nbf(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
+        given(jwtClaimsSetBuilder.iat(ArgumentMatchers.<Date>anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claim(anyString(), anyObject())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.claims(anyMap())).willReturn(jwtClaimsSetBuilder);
         given(jwtClaimsSetBuilder.build()).willReturn(claimsSet);

--- a/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/pom.xml
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/pom.xml
@@ -13,6 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2016 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -62,8 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/pom.xml
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/pom.xml
@@ -13,6 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2016 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -56,8 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/OpenIdConnectModuleTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/OpenIdConnectModuleTest.java
@@ -12,14 +12,15 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 
 package org.forgerock.jaspi.modules.openid;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/helpers/JWKSetParserTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/helpers/JWKSetParserTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 package org.forgerock.jaspi.modules.openid.helpers;
 
@@ -22,8 +23,8 @@ import java.util.Map;
 import org.forgerock.jaspi.modules.openid.exceptions.FailedToLoadJWKException;
 import org.forgerock.json.jose.jwk.KeyType;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/JWKOpenIdResolverImplTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/JWKOpenIdResolverImplTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 package org.forgerock.jaspi.modules.openid.resolvers;
 
@@ -31,7 +32,7 @@ import java.net.URL;
 import java.util.Date;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/WellKnownOpenIdConfigurationFactoryTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/WellKnownOpenIdConfigurationFactoryTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 package org.forgerock.jaspi.modules.openid.resolvers;
 
@@ -20,7 +21,7 @@ import java.net.URL;
 import org.forgerock.jaspi.modules.openid.exceptions.FailedToLoadJWKException;
 import org.forgerock.jaspi.modules.openid.helpers.SimpleHTTPClient;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceConfiguratorImplTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/test/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceConfiguratorImplTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 
 package org.forgerock.jaspi.modules.openid.resolvers.service;
@@ -23,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import org.forgerock.jaspi.modules.openid.resolvers.OpenIdResolver;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/commons/auth-filters/authn-filter/jaspi-runtime/pom.xml
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/pom.xml
@@ -13,6 +13,7 @@
   * information: "Portions copyright [year] [name of copyright owner]".
   *
   * Copyright 2013-2015 ForgeRock AS.
+  * Portions copyright 2020-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -59,8 +60,7 @@
         
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthContextsTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthContextsTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -19,8 +20,8 @@ package org.forgerock.caf.authentication.framework;
 import static org.forgerock.caf.authentication.framework.AuthStatusUtils.asString;
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.contains;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthModulesTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthModulesTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -19,11 +20,11 @@ package org.forgerock.caf.authentication.framework;
 import static org.forgerock.caf.authentication.framework.AuthStatusUtils.asString;
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyMapOf;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.contains;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFilterTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFilterTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.forgerock.caf.authentication.framework.AuthenticationFilter.AuthenticationFilterBuilder;
 import static org.forgerock.caf.authentication.framework.AuthenticationFilter.AuthenticationModuleBuilder.configureModule;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;
@@ -41,7 +42,7 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.testng.annotations.Test;
 
@@ -83,7 +84,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), responseHandlerCaptor.capture(),
                 serviceSubjectCaptor.capture(), eq(sessionAuthModule), authModulesCaptor.capture(),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
         assertThat(responseHandlerCaptor.getValue()).isNotNull();
@@ -110,7 +111,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), any(ResponseHandler.class),
                 any(Subject.class), eq(sessionAuthModule), anyListOf(AsyncServerAuthModule.class),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
     }
@@ -177,7 +178,7 @@ public class AuthenticationFilterTest {
 
         verify(builder).createFilter(loggerCaptor.capture(), eq(auditApi), responseHandlerCaptor.capture(),
                 eq(serviceSubject), eq(sessionAuthModule), authModulesCaptor.capture(),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         assertThat(loggerCaptor.getValue()).isNotNull();
         assertThat(responseHandlerCaptor.getValue()).isNotNull();
@@ -219,8 +220,8 @@ public class AuthenticationFilterTest {
 
         //Then
         verify(builder).createFilter(any(Logger.class), eq(auditApi), any(ResponseHandler.class), any(Subject.class),
-                any(AsyncServerAuthModule.class), anyListOf(AsyncServerAuthModule.class),
-                Matchers.<Promise<List<Void>, AuthenticationException>>anyObject());
+                nullable(AsyncServerAuthModule.class), anyListOf(AsyncServerAuthModule.class),
+                ArgumentMatchers.<Promise<List<Void>, AuthenticationException>>anyObject());
 
         verify(authModule).initialize(authModuleRequestPolicy, authModuleResponsePolicy,
                 authModuleHandler, authModuleSettings);

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFrameworkTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/AuthenticationFrameworkTest.java
@@ -12,13 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.authentication.framework;
 
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/JaspiAdaptersTest.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/test/java/org/forgerock/caf/authentication/framework/JaspiAdaptersTest.java
@@ -20,7 +20,7 @@ package org.forgerock.caf.authentication.framework;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.caf.authentication.framework.JaspiAdapters.MESSAGE_INFO_CONTEXT_KEY;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import javax.security.auth.Subject;

--- a/commons/auth-filters/authz-filter/framework-api/pom.xml
+++ b/commons/auth-filters/authz-filter/framework-api/pom.xml
@@ -13,6 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -38,8 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authz-filter/framework/pom.xml
+++ b/commons/auth-filters/authz-filter/framework/pom.xml
@@ -13,6 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -43,8 +44,7 @@
         </dependency>
          <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authz-filter/framework/src/test/java/org/forgerock/authz/filter/crest/AuthorizationFiltersTest.java
+++ b/commons/auth-filters/authz-filter/framework/src/test/java/org/forgerock/authz/filter/crest/AuthorizationFiltersTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.authz.filter.crest;
@@ -20,8 +21,8 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.util.test.assertj.AssertJPromiseAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.*;
@@ -48,7 +49,7 @@ import org.forgerock.json.resource.SingletonResourceProvider;
 import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.promise.Promises;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.testng.annotations.Test;
 
 public class AuthorizationFiltersTest {
@@ -204,7 +205,7 @@ public class AuthorizationFiltersTest {
         chain.handleAction(context, request);
 
         //Then
-        verify(target).actionInstance(eq(context), eq("RESOURCE_NAME"), Matchers.<ActionRequest>anyObject());
+        verify(target).actionInstance(eq(context), eq("RESOURCE_NAME"), ArgumentMatchers.<ActionRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")
@@ -296,7 +297,7 @@ public class AuthorizationFiltersTest {
         chain.handleCreate(context, request);
 
         //Then
-        verify(target).createInstance(eq(context), Matchers.<CreateRequest>anyObject());
+        verify(target).createInstance(eq(context), ArgumentMatchers.<CreateRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")
@@ -388,7 +389,7 @@ public class AuthorizationFiltersTest {
         chain.handleDelete(context, request);
 
         //Then
-        verify(target).deleteInstance(eq(context), eq("RESOURCE_NAME"), Matchers.<DeleteRequest>anyObject());
+        verify(target).deleteInstance(eq(context), eq("RESOURCE_NAME"), ArgumentMatchers.<DeleteRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")
@@ -480,7 +481,7 @@ public class AuthorizationFiltersTest {
         chain.handlePatch(context, request);
 
         //Then
-        verify(target).patchInstance(eq(context), eq("RESOURCE_NAME"), Matchers.<PatchRequest>anyObject());
+        verify(target).patchInstance(eq(context), eq("RESOURCE_NAME"), ArgumentMatchers.<PatchRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")
@@ -664,7 +665,7 @@ public class AuthorizationFiltersTest {
         chain.handleRead(context, request);
 
         //Then
-        verify(target).readInstance(eq(context), eq("RESOURCE_NAME"), Matchers.<ReadRequest>anyObject());
+        verify(target).readInstance(eq(context), eq("RESOURCE_NAME"), ArgumentMatchers.<ReadRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")
@@ -756,7 +757,7 @@ public class AuthorizationFiltersTest {
         chain.handleUpdate(context, request);
 
         //Then
-        verify(target).updateInstance(eq(context), eq("RESOURCE_NAME"), Matchers.<UpdateRequest>anyObject());
+        verify(target).updateInstance(eq(context), eq("RESOURCE_NAME"), ArgumentMatchers.<UpdateRequest>anyObject());
     }
 
     @SuppressWarnings("unchecked")

--- a/commons/auth-filters/authz-filter/modules/oauth2-module/pom.xml
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/pom.xml
@@ -13,6 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -53,8 +54,7 @@
         </dependency>
          <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/commons/auth-filters/authz-filter/modules/oauth2-module/src/test/java/org/forgerock/authz/modules/oauth2/OAuth2ModuleTest.java
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/src/test/java/org/forgerock/authz/modules/oauth2/OAuth2ModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.authz.modules.oauth2;
@@ -21,7 +22,7 @@ import static org.forgerock.authz.modules.oauth2.OAuth2Module.AccessTokenValidat
 import static org.forgerock.authz.modules.oauth2.OAuth2Module.OAUTH2_PROFILE_INFO_CONTEXT_KEY;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.testng.Assert.assertTrue;

--- a/commons/auth-filters/authz-filter/modules/oauth2-module/src/test/java/org/forgerock/authz/modules/oauth2/RestOAuth2AccessTokenValidatorTest.java
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/src/test/java/org/forgerock/authz/modules/oauth2/RestOAuth2AccessTokenValidatorTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.authz.modules.oauth2;
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;

--- a/commons/http-framework/binding-test-utils/pom.xml
+++ b/commons/http-framework/binding-test-utils/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/commons/http-framework/core/pom.xml
+++ b/commons/http-framework/core/pom.xml
@@ -14,7 +14,7 @@
 
   Copyright 2010–2011 ApexIdentity Inc.
   Portions Copyright 2011-2016 ForgeRock AS.
-  Portions Copyright 2017-2024 3A Systems, LLC.
+  Portions Copyright 2017-2026 3A Systems, LLC.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -55,8 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/ClientTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/ClientTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http;
@@ -19,7 +20,7 @@ package org.forgerock.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.http.protocol.Response.newResponsePromise;
 import static org.forgerock.util.Utils.joinAsString;
-import static org.mockito.Matchers.notNull;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -31,7 +32,7 @@ import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
 import org.forgerock.http.protocol.Status;
 import org.forgerock.util.promise.Promise;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -51,7 +52,7 @@ public final class ClientTest {
     @BeforeMethod
     public void beforeMethod() {
         initMocks(this);
-        when(handler.handle(notNull(RootContext.class), Matchers.notNull(Request.class)))
+        when(handler.handle(notNull(RootContext.class), ArgumentMatchers.notNull(Request.class)))
                 .thenReturn(newResponsePromise(new Response(Status.OK)));
         client = new Client(handler);
     }

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/filter/FiltersTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/filter/FiltersTest.java
@@ -12,13 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.filter;
 
 import static org.forgerock.http.protocol.Response.newResponsePromise;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/filter/TransactionIdInboundFilterTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/filter/TransactionIdInboundFilterTest.java
@@ -12,12 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/filter/TransactionIdOutboundFilterTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/filter/TransactionIdOutboundFilterTest.java
@@ -12,12 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/handler/HandlersTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/handler/HandlersTest.java
@@ -12,13 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.handler;
 
 import static org.forgerock.http.protocol.Response.newResponsePromise;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/routing/RouterTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/routing/RouterTest.java
@@ -12,14 +12,16 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.routing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -97,7 +99,7 @@ public class RouterTest {
         request.setUri("http://example.com:8080/json/users");
 
         given(routeMatcher.evaluate(any(Context.class), any(Request.class))).willReturn(routeMatch);
-        doThrow(IncomparableRouteMatchException.class).when(routeMatch).isBetterMatchThan(any(RouteMatch.class));
+        doThrow(IncomparableRouteMatchException.class).when(routeMatch).isBetterMatchThan(nullable(RouteMatch.class));
 
         //When
         Promise<Response, NeverThrowsException> promise = router.handle(context, request);

--- a/commons/http-framework/core/src/test/java/org/forgerock/http/routing/RoutingTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/http/routing/RoutingTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.routing;
@@ -22,7 +23,7 @@ import static org.forgerock.http.routing.RoutingMode.STARTS_WITH;
 import static org.forgerock.http.routing.Version.version;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import java.net.URI;

--- a/commons/http-framework/core/src/test/java/org/forgerock/services/routing/AbstractRouterTest.java
+++ b/commons/http-framework/core/src/test/java/org/forgerock/services/routing/AbstractRouterTest.java
@@ -12,12 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.services.routing;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -398,7 +400,7 @@ public class AbstractRouterTest {
         router.addRoute(routeOneMatcher, new TestAbstractRouter().setDefaultRoute(routeOneHandler));
         router.addRoute(routeTwoMatcher, routeTwoHandler);
         given(routeOneHandler.api(any(ApiProducer.class))).willReturn("one");
-        given(routeOneHandler.handleApiRequest(any(Context.class), eq(request))).willReturn("one");
+        given(routeOneHandler.handleApiRequest(nullable(Context.class), eq(request))).willReturn("one");
         given(routeTwoHandler.api(any(ApiProducer.class))).willReturn("two");
         router.api(new StringApiProducer());
 

--- a/commons/http-framework/oauth2/src/test/java/org/forgerock/http/oauth2/ResourceServerFilterTest.java
+++ b/commons/http-framework/oauth2/src/test/java/org/forgerock/http/oauth2/ResourceServerFilterTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.oauth2;
@@ -21,8 +22,8 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.forgerock.http.oauth2.ResourceServerFilter.WWW_AUTHENTICATE_HEADER;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/commons/http-framework/oauth2/src/test/java/org/forgerock/http/oauth2/resolver/OpenAmAccessTokenResolverTest.java
+++ b/commons/http-framework/oauth2/src/test/java/org/forgerock/http/oauth2/resolver/OpenAmAccessTokenResolverTest.java
@@ -12,12 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.oauth2.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/commons/rest/json-resource-http/src/test/java/org/forgerock/json/resource/http/RoutingTest.java
+++ b/commons/rest/json-resource-http/src/test/java/org/forgerock/json/resource/http/RoutingTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource.http;
@@ -26,8 +27,8 @@ import static org.forgerock.json.resource.Router.uriTemplate;
 import static org.forgerock.json.resource.http.HttpUtils.ETAG_ANY;
 import static org.forgerock.json.resource.http.HttpUtils.HEADER_IF_NONE_MATCH;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 

--- a/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/ResourcesTest.java
+++ b/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/ResourcesTest.java
@@ -31,8 +31,8 @@ import static org.forgerock.json.resource.TestUtils.filter;
 import static org.forgerock.json.resource.test.assertj.AssertJActionResponseAssert.assertThat;
 import static org.forgerock.json.resource.test.assertj.AssertJResourceResponseAssert.assertThat;
 import static org.forgerock.util.promise.Promises.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 

--- a/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/RouterTest.java
+++ b/commons/rest/json-resource/src/test/java/org/forgerock/json/resource/RouterTest.java
@@ -24,7 +24,7 @@ import static org.forgerock.http.routing.RoutingMode.STARTS_WITH;
 import static org.forgerock.json.resource.RouteMatchers.requestUriMatcher;
 import static org.forgerock.json.resource.Router.uriTemplate;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/commons/selfservice/stages/pom.xml
+++ b/commons/selfservice/stages/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions copyright 2020-2026 3A Systems, LLC
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -71,8 +72,7 @@
         </dependency>
          <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/captcha/CaptchaStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/captcha/CaptchaStageTest.java
@@ -12,13 +12,15 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.captcha;
 
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 import org.forgerock.http.Client;
 import org.forgerock.http.Handler;
@@ -112,7 +114,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(newEmptyJsonValue());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseFailure());
+        given(handler.handle(nullable(Context.class), any(Request.class))).willReturn(newPromiseFailure());
         // When
         captchaStage.advance(context, config);
     }
@@ -126,7 +128,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(getInputCaptchaResponse());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseFailure());
+        given(handler.handle(nullable(Context.class), any(Request.class))).willReturn(newPromiseFailure());
         // When
         captchaStage.advance(context, config);
     }
@@ -137,7 +139,7 @@ public final class CaptchaStageTest {
         config.setRecaptchaSecretKey("6Le4og4TAAAAAFPprcsXlHE9bYYPAMX794A6R3Mv");
         config.setRecaptchaUri("https://www.google.com/recaptcha/api/siteverify");
         given(context.getInput()).willReturn(getInputCaptchaResponse());
-        given(handler.handle(any(Context.class), any(Request.class))).willReturn(newPromiseSuccess());
+        given(handler.handle(nullable(Context.class), any(Request.class))).willReturn(newPromiseSuccess());
         // When
         captchaStage.advance(context, config);
     }

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/email/VerifyEmailAccountStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/email/VerifyEmailAccountStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.email;
 
@@ -25,8 +26,9 @@ import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.QUERYSTRING_PARAMS_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -201,7 +203,7 @@ public final class VerifyEmailAccountStageTest {
 
         // Then
         ArgumentCaptor<ActionRequest> actionRequestArgumentCaptor =  ArgumentCaptor.forClass(ActionRequest.class);
-        verify(connection).action(any(Context.class), actionRequestArgumentCaptor.capture());
+        verify(connection).action(nullable(Context.class), actionRequestArgumentCaptor.capture());
         ActionRequest actionRequest = actionRequestArgumentCaptor.getValue();
 
         assertThat(actionRequest.getAction()).isSameAs("send");
@@ -244,7 +246,7 @@ public final class VerifyEmailAccountStageTest {
 
         // Then
         ArgumentCaptor<ActionRequest> actionRequestArgumentCaptor =  ArgumentCaptor.forClass(ActionRequest.class);
-        verify(connection).action(any(Context.class), actionRequestArgumentCaptor.capture());
+        verify(connection).action(nullable(Context.class), actionRequestArgumentCaptor.capture());
         ActionRequest actionRequest = actionRequestArgumentCaptor.getValue();
 
         assertThat(actionRequest.getAction()).isSameAs("send");

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/kba/SecurityAnswerVerificationStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/kba/SecurityAnswerVerificationStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.kba;
 
@@ -20,7 +21,8 @@ import static org.forgerock.util.crypto.CryptoConstants.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -130,7 +132,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newEmptyJsonValue());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -150,7 +152,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUserWithOnlyOneCustomQuestion());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -170,7 +172,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUserWithOnlyOneSystemQuestion());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -190,7 +192,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         JsonValue jsonValue = securityAnswerVerificationStage.gatherInitialRequirements(context, config);
@@ -214,7 +216,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         securityAnswerVerificationStage.advance(context, config);
@@ -233,7 +235,7 @@ public final class SecurityAnswerVerificationStageTest {
 
         given(factory.getConnection()).willReturn(connection);
         given(queryResponse.getContent()).willReturn(newJsonValueUser());
-        given(connection.read(any(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
+        given(connection.read(nullable(Context.class), any(ReadRequest.class))).willReturn(queryResponse);
 
         // When
         securityAnswerVerificationStage.advance(context, config);

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/registration/UserRegistrationStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/registration/UserRegistrationStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.registration;
 
@@ -20,7 +21,8 @@ import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;
@@ -107,7 +109,7 @@ public final class UserRegistrationStageTest {
 
         // Then
         ArgumentCaptor<CreateRequest> createRequestArgumentCaptor =  ArgumentCaptor.forClass(CreateRequest.class);
-        verify(connection).create(any(Context.class), createRequestArgumentCaptor.capture());
+        verify(connection).create(nullable(Context.class), createRequestArgumentCaptor.capture());
         CreateRequest createRequest = createRequestArgumentCaptor.getValue();
 
         assertThat(createRequest.getContent()).stringAt("givenName").isEqualTo("testUser");

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/reset/ResetStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/reset/ResetStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.reset;
 
@@ -20,7 +21,8 @@ import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;
@@ -103,7 +105,7 @@ public final class ResetStageTest {
 
         // Then
         ArgumentCaptor<PatchRequest> patchRequestArgumentCaptor =  ArgumentCaptor.forClass(PatchRequest.class);
-        verify(connection).patch(any(Context.class), patchRequestArgumentCaptor.capture());
+        verify(connection).patch(nullable(Context.class), patchRequestArgumentCaptor.capture());
         PatchRequest createRequest = patchRequestArgumentCaptor.getValue();
 
         PatchOperation patchOperation = createRequest.getPatchOperations().get(0);

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/EmailUsernameStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/EmailUsernameStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -21,7 +22,8 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -136,7 +138,7 @@ public final class EmailUsernameStageTest {
 
         // Then
         ArgumentCaptor<ActionRequest> actionRequestArgumentCaptor =  ArgumentCaptor.forClass(ActionRequest.class);
-        verify(connection).action(any(Context.class), actionRequestArgumentCaptor.capture());
+        verify(connection).action(nullable(Context.class), actionRequestArgumentCaptor.capture());
         ActionRequest actionRequest = actionRequestArgumentCaptor.getValue();
 
         assertThat(actionRequest.getAction()).isSameAs("send");

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/RetrieveUsernameStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/RetrieveUsernameStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -21,7 +22,7 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.forgerock.selfservice.stages.user.RetrieveUsernameStage.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 import org.forgerock.json.JsonValue;

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/UserDetailsStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/UserDetailsStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -24,7 +25,7 @@ import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
 import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/UserQueryStageTest.java
+++ b/commons/selfservice/stages/src/test/java/org/forgerock/selfservice/stages/user/UserQueryStageTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.stages.user;
 
@@ -22,8 +23,9 @@ import static org.forgerock.selfservice.stages.CommonStateFields.EMAIL_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USER_ID_FIELD;
 import static org.forgerock.selfservice.stages.CommonStateFields.USERNAME_FIELD;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -179,7 +181,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -197,7 +199,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -215,7 +217,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);
@@ -241,7 +243,7 @@ public final class UserQueryStageTest {
                 ((QueryResourceHandler) invocation.getArguments()[2]).handleResource(resourceResponse);
                 return null;
             }
-        }).when(connection).query(any(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
+        }).when(connection).query(nullable(Context.class), any(QueryRequest.class), any(QueryResourceHandler.class));
 
         // When
         userQueryStage.advance(context, config);

--- a/commons/util/util/src/test/java/org/forgerock/util/PerItemEvictionStrategyCacheTest.java
+++ b/commons/util/util/src/test/java/org/forgerock/util/PerItemEvictionStrategyCacheTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.util;
@@ -22,9 +23,9 @@ import static org.forgerock.util.promise.Promises.newResultPromise;
 import static org.forgerock.util.promise.Promises.newRuntimeExceptionPromise;
 import static org.forgerock.util.time.Duration.UNLIMITED;
 import static org.forgerock.util.time.Duration.duration;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/commons/util/util/src/test/java/org/forgerock/util/promise/PromiseContractTest.java
+++ b/commons/util/util/src/test/java/org/forgerock/util/promise/PromiseContractTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.util.promise;
 
@@ -19,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.forgerock.util.promise.Promises.newExceptionPromise;
 import static org.forgerock.util.promise.Promises.newResultPromise;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/commons/util/util/src/test/java/org/forgerock/util/thread/ExecutorServiceFactoryTest.java
+++ b/commons/util/util/src/test/java/org/forgerock/util/thread/ExecutorServiceFactoryTest.java
@@ -12,12 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 package org.forgerock.util.thread;
 
 import org.forgerock.util.thread.listener.ShutdownListener;
 import org.forgerock.util.thread.listener.ShutdownManager;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.verify;
 import org.testng.annotations.Test;

--- a/guice/core/src/test/java/org/forgerock/guice/core/InjectorFactoryTest.java
+++ b/guice/core/src/test/java/org/forgerock/guice/core/InjectorFactoryTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2013-2015 ForgeRock AS.
+* Portions copyright 2020-2026 3A Systems, LLC
 */
 
 package org.forgerock.guice.core;
@@ -29,7 +30,7 @@ import com.google.inject.Module;
 import org.forgerock.guice.core.test.TestModule1;
 import org.forgerock.guice.core.test.TestModule2;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -72,7 +73,7 @@ public class InjectorFactoryTest {
         injectorFactory.createInjector(moduleAnnotation);
 
         //Then
-        verify(moduleCreator, times(2)).createInstance(Matchers.<Class<Module>>anyObject());
+        verify(moduleCreator, times(2)).createInstance(ArgumentMatchers.<Class<Module>>anyObject());
         ArgumentCaptor<Set> createInjectorCaptor = ArgumentCaptor.forClass(Set.class);
         verify(injectorCreator).createInjector(createInjectorCaptor.capture());
         Set<Module> modules = createInjectorCaptor.getValue();

--- a/i18n-framework/jul/src/test/java/org/forgerock/i18n/jul/LocalizedLoggerTest.java
+++ b/i18n-framework/jul/src/test/java/org/forgerock/i18n/jul/LocalizedLoggerTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  *      Copyright 2011 ForgeRock AS
+ * Portions copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.i18n.jul;
@@ -19,7 +20,7 @@ package org.forgerock.i18n.jul;
 import static org.forgerock.i18n.jul.MyTestMessages.MESSAGE_WITH_NO_ARGS;
 import static org.forgerock.i18n.jul.MyTestMessages.MESSAGE_WITH_STRING;
 import static org.forgerock.i18n.jul.MyTestMessages.MESSAGE_WITH_STRING_AND_NUMBER;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
## Summary

Resolves the **`org.mockito.Matchers` is deprecated** code-quality finding and completes the migration of all tests to **Mockito 2** (`mockito-core` 2.23.4, already managed in the root pom).

## Changes

- **11 modules** switched from the Mockito 1.x `mockito-all:1.10.19` uber-jar to `mockito-core` (managed `2.23.4`): `audit/handler-jms`, `authn-filter/jaspi-runtime`, `authn-filter/jaspi-modules/{jwt-session,openam-session,openid-connect}-module`, `authz-filter/{framework,framework-api,modules/oauth2-module}`, `http-framework/{binding-test-utils,core}`, `selfservice/stages`.
  - `binding-test-utils` keeps `compile` scope — its main class `BindingTest` uses Mockito.
- **45 test files**: `org.mockito.Matchers` → `org.mockito.ArgumentMatchers` (static imports and qualified `ArgumentMatchers.<T>anyObject()` calls). `org.hamcrest.Matchers` left untouched.
- **Adapted tests to Mockito 1→2 behavioural/API changes:**
  - `InvocationOnMock.getArgumentAt(i, Class)` → `<T>getArgument(i)` (removed in 2.x).
  - `any(Class)` → `nullable(Class)` where the actual argument is `null` (in 2.x `any(Class)` no longer matches null): `RouterTest`, `AbstractRouterTest`, `AuthenticationFilterTest`, and the self-service stage tests.
  - `JndiJmsContextManagerTest`: create all mocks **before** swapping the thread context classloader to a mock, so byte-buddy resolves classes against the real classloader (was `NoClassDefFoundError: javax/naming/Context`).

## Verification

Built and tested under **JDK 11** (the project's target). All affected modules — plus the `binding-test-utils` consumers `http-framework/servlet` and `http-framework/grizzly` — compile and their tests pass (e.g. `http-framework/core` 1059 tests, `jaspi-runtime` 218). Repo-wide: no `org.mockito.Matchers` and no `mockito-all` references remain.
