### PR TITLE
Capitalize "JavaScript" in JsonPatchJavascriptValueTransformer docs

### DIFF
--- a/commons/util/util/src/test/java/org/forgerock/json/JsonPatchJavascriptValueTransformer.java
+++ b/commons/util/util/src/test/java/org/forgerock/json/JsonPatchJavascriptValueTransformer.java
@@ -24,22 +24,22 @@ import javax.script.ScriptEngineManager;
 
 /**
  * RFC6902 expects the patch value to be a predetermined, static value to be used in the
- * patch operation's execution.  This class provides an alternate approach using javascript
+ * patch operation's execution.  This class provides an alternate approach using JavaScript
  * to potentially transform a value (or the entire document itself).
  */
 public class JsonPatchJavascriptValueTransformer implements JsonPatchValueTransformer {
     /**
      * Path to the "script" attribute of a patch entry. This attribute may be used in
-     * place of the "value" attribute to provide a javascript value transform. If both
+     * place of the "value" attribute to provide a JavaScript value transform. If both
      * "script" and "value" are present then "value" takes precedence.
      */
     private static final JsonPointer SCRIPT_PTR = new JsonPointer("/script");
 
     /**
-     * Return the value to be used for a given patch operation, transformed via javascript
+     * Return the value to be used for a given patch operation, transformed via JavaScript
      * if applicable.
      *
-     * The target document is made available to javascript through a variable named
+     * The target document is made available to JavaScript through a variable named
      * 'content'.
      *
      * @param target the patch target document.  Target is unused by default, made available


### PR DESCRIPTION
Fixes a code-quality finding: the class/method Javadoc of `JsonPatchJavascriptValueTransformer` spelled the language name as lowercase "javascript". Corrected to "JavaScript" in the prose only — the `org.mozilla.javascript` import and the class name are intentionally left untouched.

Comment-only change; no code behaviour affected.