### PR TITLE
Fix typo and temp-directory bug in ResolveExternalDependencyMojo

### DIFF
--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
@@ -16,6 +16,7 @@ package com.savage7.maven.plugin.dependency;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -207,10 +208,10 @@ public class ResolveExternalDependencyMojo extends
                             if (!new File(artifactItem.getDownloadUrl()).exists()) {
                             	URL downloadUrl = new URL(artifactItem.getDownloadUrl());
 	                            String endPointUrl = downloadUrl.getProtocol() + "://"+ downloadUrl.getAuthority();
-	                            Repository repository = new Repository("additonal-configs", endPointUrl);
+	                            Repository repository = new Repository("additional-configs", endPointUrl);
 	                            Settings settings = mavenSettingsBuilder.buildSettings();
 	                            ProxyInfo proxyInfo = null;
-	                            if (settings != null&& settings.getActiveProxy() != null)
+	                            if (settings != null && settings.getActiveProxy() != null)
 	                            {
 	                                Proxy settingsProxy = settings.getActiveProxy();
 	                                proxyInfo = new ProxyInfo();
@@ -352,8 +353,7 @@ public class ResolveExternalDependencyMojo extends
                                     + "compressed file: "
                                     + artifactItem.getExtractFile());
 
-                            File tempOutputDir = FileUtils.createTempFile(tempDownloadFile.getName(), ".dir", null);
-                            tempOutputDir.mkdirs();
+                            File tempOutputDir = Files.createTempDirectory(tempDownloadFile.getName() + ".dir").toFile();
                             File extractedFile = new File(tempOutputDir, artifactItem.getExtractFile());
                             
                             UnArchiver unarchiver;


### PR DESCRIPTION
Completes the fixes drafted in the WIP PR #194 (which contained only an "Initial plan" commit, no changes).

Changes in `ResolveExternalDependencyMojo`:

- Correct the repository id typo `additonal-configs` → `additional-configs`.
- Add the missing space in the `settings != null &&` condition.
- Replace `FileUtils.createTempFile(...)` + `mkdirs()` with `Files.createTempDirectory(...)`. `createTempFile` creates a *file*, so the subsequent `mkdirs()` on it failed and extraction targeted a non-existent directory; `createTempDirectory` creates the directory directly.

The module compiles (`mvn compile`).