### PR TITLE
Add CodeQL advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,81 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+  schedule:
+    # Weekly run, Mondays at 03:27 UTC
+    - cron: '27 3 * * 1'
+  # Allows running this workflow manually from the Actions tab or via the gh CLI.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to avoid the long-running,
+# eventually-cancelled analyses seen with the previous default setup.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required to upload results to code scanning.
+      security-events: write
+      # Only needed for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # This large multi-module Maven build is expensive to compile, so we
+          # use build-mode 'none': CodeQL builds its model straight from the
+          # Java/Kotlin sources without invoking Maven. This avoids the long,
+          # eventually-cancelled autobuild that the previous default setup hit.
+          #
+          # For higher precision (dataflow through compiled dependencies) switch
+          # this to 'manual' and uncomment the "Build with Maven" step below.
+          - language: java-kotlin
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      # --- Manual build (only used when build-mode is 'manual') -------------
+      # - name: Set up JDK 11
+      #   uses: actions/setup-java@v5
+      #   with:
+      #     java-version: '11'
+      #     distribution: 'zulu'
+      # - name: Cache Maven packages
+      #   uses: actions/cache@v5
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.os }}-m2-repository-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-m2-repository
+      # - name: Build with Maven
+      #   env:
+      #     MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
+      #   run: mvn --batch-mode --errors -DskipTests -Dmaven.test.skip=true clean compile --file pom.xml
+      # ---------------------------------------------------------------------
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What & why

Adds `.github/workflows/codeql.yml` — an advanced setup for GitHub Code Scanning.

Reason: the previous CodeQL **default setup** (run 23841659052, 2026-04-01) was cancelled by the `github-advanced-security` bot. The autobuild of this heavy multi-module Maven project ran for 2h46m on python/javascript while java/ruby were cancelled immediately. The analysis never completed, so no alerts were produced (`no analysis found`). Default setup is currently `not-configured`.

## Solution

- **Only `java-kotlin`** — dropped ruby/python/js, which the project doesn't really contain (0 Kotlin files, 1886 Java) and which slowed the run down.
- **`build-mode: none`** — CodeQL builds its model straight from the sources without invoking Maven, removing the risk of repeating the stuck/cancelled autobuild. A commented-out manual build block is kept in the file for higher-precision analysis (`manual`).
- **`queries: security-and-quality`** — extended query suite.
- **`concurrency` + `cancel-in-progress`** — a new push on the same ref cancels the in-progress analysis so runs don't pile up.
- Triggers: push/PR to `master`, weekly schedule, manual `workflow_dispatch`.

## Note

This workflow conflicts with CodeQL default setup — while using the workflow file, keep default setup disabled, otherwise the bot will start cancelling runs again.