### PR TITLE
Guard tainted numeric cast in Uris.urlDecode0 (CodeQL java/tainted-numeric-cast)

### DIFF
--- a/commons/http-framework/core/src/main/java/org/forgerock/http/util/Uris.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/util/Uris.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.http.util;
@@ -416,11 +417,14 @@ public final class Uris {
                     final String hexPair = s.substring(i + 1, i + 3);
                     try {
                         final int octet = Integer.parseInt(hexPair, 16);
-                        if (octet < 0) {
+                        if (octet < 0 || octet > 0xFF) {
                             throw new IllegalArgumentException(
                                     "Path contains an invalid percent encoding '" + hexPair + "'");
                         }
-                        buffer[bufferPos++] = (byte) octet;
+                        // octet is a single unsigned byte (0x00-0xFF); mask the
+                        // low 8 bits so the narrowing to byte is explicit and
+                        // preserves the full 0x80-0xFF range for the UTF-8 decode.
+                        buffer[bufferPos++] = (byte) (octet & 0xFF);
                     } catch (NumberFormatException e) {
                         throw new IllegalArgumentException(
                                 "Path contains an invalid percent encoding '" + hexPair + "'");


### PR DESCRIPTION
## Summary

Fixes the CodeQL critical alert `java/tainted-numeric-cast` (#21) in `Uris.urlDecode0`.

When decoding a percent-encoded URL octet, the parsed value flows from user-controlled input into a narrowing cast to `byte`, which CodeQL flags as a potentially truncating tainted cast.

## Change

- Validate the octet to the single unsigned-byte range `0x00–0xFF` (previously only `< 0` was rejected).
- Make the narrowing explicit with a low-8-bit mask `(byte) (octet & 0xFF)`, documenting that the full `0x80–0xFF` range is intended for the subsequent UTF-8 decode.

## Behavior

No behavioral change: a percent-encoding octet is always 2 hex digits, so the value is already in `[0, 255]`; the mask is a no-op and the explicit range check only rejects input that was already unreachable. `UrisTest` (54 tests) still passes.