### PR TITLE
Use AES/CBC instead of AES/ECB for the JSON session-key cipher (CodeQL java/weak-cryptographic-algorithm)

### DIFF
--- a/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/simple/SimpleEncryptor.java
+++ b/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/simple/SimpleEncryptor.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.crypto.simple;
@@ -100,13 +101,18 @@ public class SimpleEncryptor implements JsonEncryptor {
      * @throws IOException if an I/O exception occurred.
      */
     private Object asymmetric(Object object) throws GeneralSecurityException, IOException {
-        String symmetricCipher = "AES/ECB/PKCS5Padding"; // no IV required for randomly-generated session key
+        // Use CBC with a random IV rather than ECB; ECB leaks plaintext block
+        // patterns regardless of session-key freshness (CWE-327). The IV is stored
+        // alongside the data and the self-describing "cipher" field keeps this
+        // backward compatible with values previously written using ECB.
+        String symmetricCipher = "AES/CBC/PKCS5Padding";
         KeyGenerator generator = KeyGenerator.getInstance("AES");
         generator.init(128);
         SecretKey sessionKey = generator.generateKey();
         Cipher symmetric = Cipher.getInstance(symmetricCipher);
         symmetric.init(Cipher.ENCRYPT_MODE, sessionKey);
         String data = Base64.encode(symmetric.doFinal(mapper.writeValueAsBytes(object)));
+        byte[] iv = symmetric.getIV();
         Cipher asymmetric = Cipher.getInstance(cipher);
         asymmetric.init(Cipher.ENCRYPT_MODE, key);
         HashMap<String, Object> keyObject = new HashMap<>();
@@ -117,6 +123,9 @@ public class SimpleEncryptor implements JsonEncryptor {
         result.put("cipher", symmetricCipher);
         result.put("key", keyObject);
         result.put("data", data);
+        if (iv != null) {
+            result.put("iv", Base64.encode(iv));
+        }
         return result;
     }
 


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#33** (`java/weak-cryptographic-algorithm`, high / CWE-327).

`SimpleEncryptor.asymmetric()` in `json-crypto` encrypted the payload with a freshly generated AES session key under **`AES/ECB/PKCS5Padding`**. ECB is deterministic: it leaks equality of plaintext blocks within a single message regardless of how fresh or random the session key is, so the "no IV required for a randomly-generated session key" assumption in the old comment was incorrect.

## Change

- Switch the session-key cipher to **`AES/CBC/PKCS5Padding`**.
- Store the randomly generated IV in the encrypted object, mirroring the existing `symmetric()` path.

This aligns the asymmetric path with the `AES/CBC/PKCS5Padding` default already used by the symmetric path, the CLI (`Main.DEFAULT_CIPHER`) and the tests.

## Backward compatibility

`SimpleDecryptor` is **self-describing** — it reads the `cipher` field and the optional `iv` from the encrypted object:

- Values previously written with `AES/ECB` (no `iv`) still decrypt as ECB.
- New values carry `cipher = AES/CBC/PKCS5Padding` + `iv` and decrypt as CBC.

No decryptor change is required, and existing/older decryptor versions remain interoperable.

## Testing

- `json-crypto/core` — `JsonCryptoTest`: **4/4 pass** (incl. `testAsymmetricEncryption` round-trip and `testDroppedIV`).
- `json-crypto/cli` — `MainTest`: **1/1 pass**.
- Both modules build (`mvn -o` offline): **BUILD SUCCESS**.
