### PR TITLE
Use RSA 2048-bit keys in json-crypto/json-web-token tests (CodeQL java/insufficient-key-size)

### DIFF
--- a/commons/json-crypto/core/src/test/java/org/forgerock/json/crypto/JsonCryptoTest.java
+++ b/commons/json-crypto/core/src/test/java/org/forgerock/json/crypto/JsonCryptoTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.crypto;
@@ -77,9 +78,9 @@ public class JsonCryptoTest {
         kg.init(128); // the Sun JRE out of the box restricts to 128-bit key length
         secretKey = kg.generateKey();
 
-        // generate RSA 1024-bit key pair
+        // generate RSA 2048-bit key pair
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        kpg.initialize(2048);
         KeyPair kp = kpg.genKeyPair();
         publicKey = kp.getPublic();
         privateKey = kp.getPrivate();

--- a/commons/json-web-token/src/test/java/org/forgerock/json/jose/jwk/RsaJWKTest.java
+++ b/commons/json-web-token/src/test/java/org/forgerock/json/jose/jwk/RsaJWKTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2020-2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwk;
@@ -335,7 +336,7 @@ public class RsaJWKTest {
         KeyPair keypair = null;
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(1024);
+            generator.initialize(2048);
             keypair = generator.genKeyPair();
         } catch (Exception e) {
             assertFalse(false, e.getLocalizedMessage());
@@ -358,7 +359,7 @@ public class RsaJWKTest {
         KeyPair keypair = null;
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(1024);
+            generator.initialize(2048);
             keypair = generator.genKeyPair();
         } catch (Exception e) {
             assertFalse(false, e.getLocalizedMessage());
@@ -384,7 +385,7 @@ public class RsaJWKTest {
         KeyPair keypair = null;
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(1024);
+            generator.initialize(2048);
             keypair = generator.genKeyPair();
         } catch (Exception e) {
             assertFalse(false, e.getLocalizedMessage());


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alerts **#17, #18, #19, #20** (`java/insufficient-key-size`, high / CWE-326).

`RsaJWKTest` and `JsonCryptoTest` generated ephemeral RSA key pairs with a **1024-bit** modulus, which CodeQL flags as below the recommended **2048-bit** minimum.

## Change

Bump the RSA key size from 1024 to 2048 bits at all four test key-generation sites:

- `json-crypto/core` — `JsonCryptoTest#beforeClass`
- `json-web-token` — `RsaJWKTest` (3 tests: public key, public+private key, public+private cert)

The keys are throwaway test fixtures with no production impact (the `main` sources contain no 1024/512-bit RSA), but bumping them removes the finding and keeps the test crypto aligned with current best practice.

## Backward compatibility / correctness

The affected tests assert round-trip properties (modulus/exponent equality, JWK encode/decode, encrypt/decrypt) that are **independent of key size**, so they pass unchanged.

## Testing

- `json-crypto/core` — `JsonCryptoTest`: **4/4 pass**.
- `json-web-token` — `RsaJWKTest`: **13/13 pass**.
- Both modules build (`mvn -o` offline): **BUILD SUCCESS**.
