### PR TITLE
Exclude test and integration-test sources from CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,14 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
+          # Exclude test and integration-test sources. With build-mode 'none'
+          # CodeQL extracts straight from source, so paths-ignore reliably
+          # scopes the analysis (it is honored for compiled languages only when
+          # build-mode is 'none').
+          config: |
+            paths-ignore:
+              - '**/src/test/**'
+              - '**/src/it/**'
 
       # --- Manual build (only used when build-mode is 'manual') -------------
       # - name: Set up JDK 11


### PR DESCRIPTION
## Summary

Scope CodeQL analysis to production code by excluding test and integration-test sources.

The `CodeQL` workflow analyzes `java-kotlin` with `build-mode: none`, so CodeQL builds its model directly from source. Under `build-mode: none`, `paths-ignore` is honored for compiled languages (with `autobuild`/`manual` it is not — scope must be controlled via the build). This adds a `config` block to the `Initialize CodeQL` step:

```yaml
config: |
  paths-ignore:
    - '**/src/test/**'
    - '**/src/it/**'
```

`**/src/test/**` and `**/src/it/**` cover the standard Maven unit- and integration-test source/resource directories across every module in the monorepo.

## Why

Test sources generate recurring, low-value code-scanning alerts (e.g. `java/comparison-with-wider-type` in the persistit `stress`/`recovery` tests) that have to be dismissed one by one. Ignoring these paths stops the noise at the source.

## Effect

- Test/integration-test code is no longer analyzed; production sources are unaffected.
- Existing open alerts whose locations fall under the ignored paths will be closed automatically on the next analysis run.
- No change to the query suite (`security-and-quality`) or build mode.

## Validation

The workflow YAML parses cleanly and the embedded `config` deserializes to `{ paths-ignore: ['**/src/test/**', '**/src/it/**'] }`.
