### PR TITLE
Make the narrowing cast explicit in ByteArrayBranchingStream.skip (CodeQL java/implicit-cast-in-compound-assignment)

### DIFF
--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/ByteArrayBranchingStream.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/ByteArrayBranchingStream.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.io;
@@ -86,9 +87,11 @@ final class ByteArrayBranchingStream extends BranchingInputStream {
         if (n <= 0) {
             return 0;
         }
-        n = Math.min(n, data.length - position);
-        position += n;
-        return n;
+        // Math.min bounds the result to data.length - position, which fits in an int
+        // (position is always in [0, data.length]), so this narrowing cast is lossless.
+        final int skipped = (int) Math.min(n, data.length - position);
+        position += skipped;
+        return skipped;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#1** (`java/implicit-cast-in-compound-assignment`, high) in `ByteArrayBranchingStream`.

`skip(long n)` clamped `n` and then accumulated it into the `int` field `position`:

```java
public synchronized long skip(long n) {
    if (n <= 0) {
        return 0;
    }
    n = Math.min(n, data.length - position);
    position += n;   // int += long -> implicit narrowing of long to int
    return n;
}
```

`position += n` implicitly narrows the `long` back to `int`.

## Why it is safe / the change

There is no real overflow: `Math.min` bounds the value to `data.length - position`, and `position` is always in `[0, data.length]`, so the result fits in an `int` and `position + skipped` never exceeds `data.length`. The change makes the narrowing explicit and keeps the arithmetic in `int`:

```java
public synchronized long skip(long n) {
    if (n <= 0) {
        return 0;
    }
    // Math.min bounds the result to data.length - position, which fits in an int
    // (position is always in [0, data.length]), so this narrowing cast is lossless.
    final int skipped = (int) Math.min(n, data.length - position);
    position += skipped;
    return skipped;
}
```

`return skipped` widens `int` back to `long` automatically. Behaviour is identical for all inputs.

## Testing

`commons/http-framework/core` compiles on JDK 11: **BUILD SUCCESS**.
