### PR TITLE
Release the write lock in ScriptRegistryImpl.removeSourceUnit (CodeQL java/unreleased-lock)

### DIFF
--- a/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -705,7 +706,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             try {
                 sourceCache.remove(unit);
             } finally {
-                sourceCacheLock.writeLock().lock();
+                sourceCacheLock.writeLock().unlock();
             }
 
             for (LibraryRecord cacheRecord : cache.values()) {


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#38** (`java/unreleased-lock`, medium) in `ScriptRegistryImpl`.

`removeSourceUnit` handled a `SourceContainer` like this:

```java
sourceCacheLock.writeLock().lock();
try {
    sourceCache.remove(unit);
} finally {
    sourceCacheLock.writeLock().lock();   // should be unlock()
}
```

The `finally` block re-acquired the write lock instead of releasing it. Every call thus incremented the write hold count by two and released it zero times, permanently leaking the lock and eventually deadlocking all readers and writers of `sourceCache`.

The alert anchors to the `writeLock().lock()` in `addSourceUnit` (which is correctly paired), but the actual defect is this `finally` block in `removeSourceUnit`.

## The change

Release the lock with `writeLock().unlock()` in the `finally`, matching the balanced acquire/release already used in `addSourceUnit`.

## Note (not changed here)

The same block calls `sourceCache.remove(unit)`, but `sourceCache` is keyed by `ScriptName` (`unit.getName()`), so the removal never matches and is a no-op. Left out of this PR to keep it scoped to the lock alert; can be addressed separately.

## Testing

`script/common` compiles on JDK 11: **BUILD SUCCESS**.
