### PR TITLE
Default JWT session cookie to Secure (CodeQL java/insecure-cookie)

### DIFF
--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -191,7 +191,9 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
         Boolean httpOnly = (Boolean) options.get(HTTP_ONLY_COOKIE_KEY);
         this.isHttpOnly = httpOnly == null ? false : httpOnly;
         Boolean secure = (Boolean) options.get(SECURE_COOKIE_KEY);
-        this.isSecure = secure == null ? false : secure;
+        // Secure-by-default: session cookies carry the Secure attribute unless the
+        // deployment explicitly opts out with isSecure=false (CodeQL java/insecure-cookie).
+        this.isSecure = secure == null ? true : secure;
         cookieDomains = (Collection<String>) options.get(COOKIE_DOMAINS_KEY);
         if (cookieDomains == null || cookieDomains.isEmpty()) {
             cookieDomains = Collections.singleton(null);


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#5** (`java/insecure-cookie`, medium) in the JWT session module.

The JWT session cookie holds an authenticated session, but `AbstractJwtSessionModule.initialize()` defaulted the `isSecure` module option to `false` when it was left unset:

```java
Boolean secure = (Boolean) options.get(SECURE_COOKIE_KEY);
this.isSecure = secure == null ? false : secure;   // insecure default
```

With the default, `createCookies()` calls `cookie.setSecure(false)`, so the browser will send the session cookie over plain HTTP — exposing it to MITM session hijacking on end-to-end HTTP deployments.

## The change

Flip the default to `true` — session cookies are now marked `Secure` unless the deployment explicitly opts out with `isSecure=false`:

```java
Boolean secure = (Boolean) options.get(SECURE_COOKIE_KEY);
// Secure-by-default: session cookies carry the Secure attribute unless the
// deployment explicitly opts out with isSecure=false (CodeQL java/insecure-cookie).
this.isSecure = secure == null ? true : secure;
```

`isSecure` remains a first-class, documented module option (`SECURE_COOKIE_KEY = "isSecure"`); only the default changed. The single change point covers both the Servlet (`ServletJwtSessionModule`) and non-Servlet (`JwtSessionModule`) modules, which share this base class.

## Compatibility

- Deployments that already set `isSecure` explicitly: **unaffected**.
- Deployments behind a TLS-terminating proxy (browser ⇄ HTTPS ⇄ proxy ⇄ HTTP app): **unaffected** — the browser still negotiates HTTPS, so the `Secure` cookie is sent.
- Genuine end-to-end plain-HTTP setups (typically dev/test): must now set `isSecure=false` explicitly to keep receiving the cookie.

## Testing

`jwt-session-module` on JDK 11: **BUILD SUCCESS**, `Tests run: 29, Failures: 0, Errors: 0, Skipped: 0`. No existing test asserts the cookie's `Secure` attribute, so the default flip breaks none of them.
