### PR TITLE
Verify SMTP server identity in ExampleEmailService (CodeQL java/insecure-smtp-ssl)

### DIFF
--- a/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleEmailService.java
+++ b/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleEmailService.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.selfservice.example;
@@ -115,6 +115,10 @@ final class ExampleEmailService implements SingletonResourceProvider {
         Properties props = new Properties();
         props.put("mail.smtp.auth", "true");
         props.put("mail.smtp.starttls.enable", "true");
+        // Require STARTTLS (reject a plaintext downgrade) and verify the SMTP
+        // server's certificate identity to prevent MITM (CodeQL java/insecure-smtp-ssl).
+        props.put("mail.smtp.starttls.required", "true");
+        props.put("mail.smtp.ssl.checkserveridentity", "true");
         props.put("mail.smtp.host", host);
         props.put("mail.smtp.port", port);
 


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#89** (`java/insecure-smtp-ssl`, medium) in `ExampleEmailService`.

The example email service enabled STARTTLS but never verified the SMTP server's identity:

```java
props.put("mail.smtp.auth", "true");
props.put("mail.smtp.starttls.enable", "true");   // opportunistic TLS, no identity check
props.put("mail.smtp.host", host);
```

`mail.smtp.starttls.enable` alone requests opportunistic TLS but does not authenticate the server: `mail.smtp.ssl.checkserveridentity` is left unset, so the server certificate's identity is not checked, and STARTTLS can be stripped by a plaintext downgrade. Either way the session — and the SMTP credentials it carries — is exposed to a man-in-the-middle.

## The change

Harden the example mail session:

```java
props.put("mail.smtp.starttls.enable", "true");
// Require STARTTLS (reject a plaintext downgrade) and verify the SMTP
// server's certificate identity to prevent MITM (CodeQL java/insecure-smtp-ssl).
props.put("mail.smtp.starttls.required", "true");
props.put("mail.smtp.ssl.checkserveridentity", "true");
```

- `mail.smtp.starttls.required=true` — refuse to send if the server does not offer STARTTLS (no plaintext downgrade).
- `mail.smtp.ssl.checkserveridentity=true` — verify the server certificate matches the host.

This is example/demo code that downstream users copy, so it should model a secure SMTP configuration.

## Testing

`commons/selfservice/example` on JDK 11: **BUILD SUCCESS** (module compiles). The change only adds two JavaMail session properties; no behavior is exercised by tests.
