### PR TITLE
Make double-checked-locking fields volatile (CodeQL java/unsafe-double-checked-locking)

### DIFF
--- a/commons/util/util/src/main/java/org/forgerock/util/LazyList.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/LazyList.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.util;
@@ -32,7 +33,7 @@ import java.util.ListIterator;
 public class LazyList<E> implements List<E> {
 
     /** The list that this lazy list exposes, once initialized. */
-    private List<E> list;
+    private volatile List<E> list;
 
     /** Factory to create the instance of the list to expose. */
     protected Factory<List<E>> factory;

--- a/commons/util/util/src/main/java/org/forgerock/util/LazyMap.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/LazyMap.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.util;
@@ -33,7 +34,7 @@ import java.util.Set;
 public class LazyMap<K, V> implements Map<K, V> {
 
     /** The map that this lazy map exposes, once initialized. */
-    private Map<K, V> map;
+    private volatile Map<K, V> map;
 
     /** Factory to create the instance of the map to expose. */
     protected Factory<Map<K, V>> factory;

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
@@ -2,6 +2,7 @@
  * DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2012-2014 ForgeRock AS. All rights reserved.
+ * Portions copyright 2026 3A Systems LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -48,7 +49,7 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
 
     public static final String LANGUAGE_NAME = "Groovy";
 
-    private GroovyScriptEngineImpl engine = null;
+    private volatile GroovyScriptEngineImpl engine = null;
 
     static {
         names = new ArrayList<String>(2);

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
@@ -2,7 +2,6 @@
  * DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2012-2014 ForgeRock AS. All rights reserved.
- * Portions copyright 2026 3A Systems LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -21,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.script.groovy;

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngineFactory.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngineFactory.java
@@ -25,6 +25,7 @@
 
 /*
  * Portions Copyrighted 2012-2014 ForgeRock AS
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.script.javascript;
@@ -54,7 +55,7 @@ public class RhinoScriptEngineFactory implements ScriptEngineFactory {
     private static List<String> mimeTypes;
     private static List<String> extensions;
 
-    private RhinoScriptEngine engine = null;
+    private volatile RhinoScriptEngine engine = null;
 
     static {
         names = new ArrayList(6);


### PR DESCRIPTION
## Summary

Resolves the **4** CodeQL `java/unsafe-double-checked-locking` code-scanning alerts (all first-party code).

Each class lazily initializes a field with the classic double-checked locking (DCL) idiom, but the field was **non-volatile**:

```java
if (field == null) {
    synchronized (this) {
        if (field == null) {
            field = ...;
        }
    }
}
return field;
```

Under the Java Memory Model, a second thread taking the fast path (the first `null` check, outside the lock) may observe a non-null reference to an object whose constructor has not finished — the constructing thread's writes can be reordered after the reference publication. DCL is only correct when the field is `volatile`, which introduces the happens-before edge guaranteeing safe publication.

## The change

Mark the four lazily-published fields `volatile` — no logic changes:

| Class | Field |
|---|---|
| `org.forgerock.util.LazyList` | `list` |
| `org.forgerock.util.LazyMap` | `map` |
| `GroovyScriptEngineFactory` | `engine` |
| `RhinoScriptEngineFactory` | `engine` |

A static holder idiom does not fit here: `LazyList`/`LazyMap` publish a per-instance field produced by an injected `Factory`, and the script factories build the engine from arguments supplied on the first `getScriptEngine(...)` call — so `volatile` DCL is the appropriate fix.

## Testing

`commons/util/util`, `script/groovy` and `script/javascript` compile.
