### PR TITLE
Lock on a stable trunk, flag closed separately (CodeQL java/unsafe-sync-on-field)

### DIFF
--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.http.io;
@@ -32,7 +33,10 @@ import org.forgerock.util.Factory;
 final class BranchingStreamWrapper extends BranchingInputStream {
 
     /** A shared object by all branches of the same input stream. */
-    private Trunk trunk;
+    private final Trunk trunk;
+
+    /** Whether this branch has been closed. */
+    private volatile boolean closed;
 
     /** This branch's position relative to the trunk buffer. */
     private int position;
@@ -79,7 +83,7 @@ final class BranchingStreamWrapper extends BranchingInputStream {
     }
 
     boolean isClosed() {
-        return trunk == null;
+        return closed;
     }
 
     @Override
@@ -156,8 +160,12 @@ final class BranchingStreamWrapper extends BranchingInputStream {
     @Override
     public void close() throws IOException {
         // multiple calls to close are harmless
-        if (trunk != null) {
+        if (!closed) {
             synchronized (trunk) {
+                if (closed) {
+                    // another thread (e.g. the finalizer) already closed this branch
+                    return;
+                }
                 try {
                     closeBranches();
                     trunk.branches.remove(this);
@@ -169,7 +177,7 @@ final class BranchingStreamWrapper extends BranchingInputStream {
                     }
                 } finally {
                     // if all else fails, this branch thinks it's closed
-                    trunk = null;
+                    closed = true;
                 }
             }
         }
@@ -230,7 +238,7 @@ final class BranchingStreamWrapper extends BranchingInputStream {
      * Throws an {@link IOException} if the stream is closed.
      */
     private void notClosed() throws IOException {
-        if (trunk == null) {
+        if (closed) {
             throw new IOException("stream is closed");
         }
     }


### PR DESCRIPTION
## Summary

Resolves the CodeQL `java/unsafe-sync-on-field` code-scanning alert in `BranchingStreamWrapper`.

The wrapper synchronizes on its `trunk` field to coordinate all branches that share a single `Trunk`. The problem: `close()` also **reassigned** that field (`trunk = null`) to mark the branch closed. Synchronizing on a field that is reassigned is unsafe — the lock object itself is mutated, so a concurrent caller can lock a different object (or hit `synchronized(null)`).

## The change

The `trunk` field was doing two jobs: **shared lock** and **closed-flag**. Split them:

- **`trunk` is now `final`** — the shared `Trunk` monitor is stable and can never be swapped or nulled while it is being used as a lock.
- **A new `volatile boolean closed`** tracks the closed state instead of nulling `trunk`. `isClosed()` / `notClosed()` consult the flag; `close()` sets it in the `finally` block.

An added re-check of `closed` **inside** the `synchronized` block keeps `close()` single-shot when a second caller races with it (e.g. an explicit `close()` concurrent with the finalizer's `close()`). The previous code could `NullPointerException` in exactly that window, because the first caller had already nulled `trunk` while the second was blocked entering the monitor.

No functional/behavioural change to the single-threaded read/branch/copy/close paths.

## Testing

`commons/http-framework/core` compiles; `BranchingStreamWrapperTest` passes — **Tests run: 116, Failures: 0, Errors: 0, Skipped: 0**.
