### PR TITLE
Remove source unit by its ScriptName key (CodeQL java/type-mismatch-modification)

### DIFF
--- a/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyrighted 2026 3A Systems, LLC
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -703,7 +704,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         } else if (unit instanceof SourceContainer) {
             sourceCacheLock.writeLock().lock();
             try {
-                sourceCache.remove(unit);
+                sourceCache.remove(unit.getName());
             } finally {
                 sourceCacheLock.writeLock().lock();
             }


### PR DESCRIPTION
## Summary

Resolves the CodeQL `java/type-mismatch-modification` alert in `ScriptRegistryImpl.removeSourceUnit`.

`sourceCache` is keyed by `ScriptName`:

```java
private final LinkedHashMap<ScriptName, SourceContainer> sourceCache = ...;
```

but the removal passed the `SourceUnit` instead of its key:

```java
- sourceCache.remove(unit);              // SourceUnit never equals a ScriptName key -> silent no-op
+ sourceCache.remove(unit.getName());    // getName() returns the ScriptName key
```

`Map.remove(Object)` accepts any type, so this compiled without warning, but a `SourceUnit` never `equals()` a `ScriptName`, so the entry was never removed — `removeSourceUnit` silently failed to evict the container. The fix mirrors the matching insertion, `sourceCache.put(unit.getName(), container)`.

## Note

The same `finally` block also contains an unrelated unreleased-lock bug (`writeLock().lock()` instead of `unlock()`); that is fixed separately in **#208**. This PR touches only line 706, so the two changes do not overlap.

## Testing

`script/common` compiles.
