### PR TITLE
Remove dead equals overload on BundleHandlerBuilder (CodeQL java/wrong-equals-signature)

### DIFF
--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandlerBuilder.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandlerBuilder.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2012 ForgeRock AS. All Rights Reserved
+ * Portions copyright 2026 3A Systems LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -84,15 +85,6 @@ public class BundleHandlerBuilder {
 
     public BundleHandler build(String bundleURL) throws MalformedURLException {
         return build(new URL(bundleURL));
-    }
-
-    public boolean equals(BundleHandlerBuilder that) {
-        if (this == that)
-            return true;
-        if ((that == null)
-                || (!actions.equals(that.actions) || !startLevel.equals(that.startLevel)))
-            return false;
-        return true;
     }
 
 }

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandlerBuilder.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandlerBuilder.java
@@ -2,7 +2,6 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2012 ForgeRock AS. All Rights Reserved
- * Portions copyright 2026 3A Systems LLC.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -21,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.commons.launcher;


### PR DESCRIPTION
## Summary

Resolves the CodeQL `java/wrong-equals-signature` alert in `BundleHandlerBuilder`.

The class declared:

```java
public boolean equals(BundleHandlerBuilder that) { ... }
```

This **overloads** rather than **overrides** `Object.equals(Object)`, so it is never dispatched by collections, `==`-vs-`equals` code, or `Objects.equals`. Beyond the wrong signature it is also:

- **dead** — no caller anywhere invokes `equals` on a `BundleHandlerBuilder` (the type is only ever used via its `newBuilder(...)` / `build(...)` factory methods);
- **contract-incomplete** — there is no matching `hashCode()`;
- **buggy** — `startLevel` is a nullable `Integer` (e.g. `newBuilder((Integer) null)`), so `startLevel.equals(...)` would `NullPointerException`.

## The change

Remove the dead, broken overload rather than promote it to a real `equals(Object)` (which would also require adding a `hashCode()` for functionality nothing uses):

```java
- public boolean equals(BundleHandlerBuilder that) {
-     if (this == that)
-         return true;
-     if ((that == null)
-             || (!actions.equals(that.actions) || !startLevel.equals(that.startLevel)))
-         return false;
-     return true;
- }
```

## Testing

`commons/launcher/launcher` compiles.
