### PR TITLE
Fix and clean up constant comparisons flagged by CodeQL java/constant-comparison

### DIFF
--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
@@ -670,7 +670,7 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         if (index < 0) {
             throw new JsonValueException(this, "List index out of range: " + index);
         }
-        if (isList() && index >= 0) {
+        if (isList()) {
             List<Object> list = asList();
             if (index < list.size()) {
                 result = list.get(index);

--- a/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
+++ b/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.json.schema;
@@ -254,7 +255,7 @@ public final class Main {
         Validator validator = schemaCache.get(schemaId);
         if (null != validator) {
             if (verbose) {
-                final boolean[] valid = new boolean[1];
+                final boolean[] valid = { true };
                 validator.validate(value.getObject(), null, new ErrorHandler() {
                     @Override
                     public void error(ValidationException exception) throws SchemaException {
@@ -267,7 +268,7 @@ public final class Main {
                     public void assembleException() throws ValidationException {
                     }
                 });
-                if (valid.length == 0) {
+                if (valid[0]) {
                     System.out.println("OK - Object is valid!");
                 }
             } else {

--- a/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
+++ b/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
@@ -13,6 +13,7 @@
  *
  * Copyright © 2010–2011 ApexIdentity Inc. All rights reserved.
  * Portions Copyrighted 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.json;
@@ -853,7 +854,7 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         if (index < 0) {
             throw new JsonValueException(this, "List index out of range: " + index);
         }
-        if (isList() && index >= 0) {
+        if (isList()) {
             final List<Object> list = asList();
             if (index < list.size()) {
                 result = list.get(index);

--- a/persistit/core/src/main/java/com/persistit/Buffer.java
+++ b/persistit/core/src/main/java/com/persistit/Buffer.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
  * Copyright 2015 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4384,9 +4385,6 @@ public class Buffer extends SharedResource {
                 keep = TAILBLOCK_HDR_SIZE_DATA + tbKLength;
                 if (tbSize - keep >= LONGREC_PREFIX_SIZE && Util.getByte(bytes, tail + keep) == LONGREC_TYPE) {
                     keep += LONGREC_PREFIX_OFFSET;
-                }
-                if (keep < TAILBLOCK_HDR_SIZE_DATA && keep > tbSize) {
-                    keep = tbSize;
                 }
             } else {
                 keep = TAILBLOCK_HDR_SIZE_DATA;

--- a/persistit/core/src/main/java/com/persistit/FastIndex.java
+++ b/persistit/core/src/main/java/com/persistit/FastIndex.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2011-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -275,7 +276,6 @@ class FastIndex {
         int ebc0;
         int ebc = -1;
         int ebc2 = Buffer.decodeKeyBlockEbc(_buffer.getInt(start));
-        int faultAt = -1;
 
         for (int i = 0, p = start; p < end; i++, p += Buffer.KEYBLOCK_LENGTH) {
             ebc0 = ebc;
@@ -284,16 +284,10 @@ class FastIndex {
                     + Buffer.KEYBLOCK_LENGTH)) : 0;
             if (ebc2 > ebc) {
                 if (getRunCount(i) >= 0) {
-                    if (faultAt < 0) {
-                        faultAt = i;
-                    }
                     return false;
                 }
             } else if (ebc > ebc0) {
                 if (getRunCount(i) < 0) {
-                    if (faultAt < 0) {
-                        faultAt = i;
-                    }
                     return false;
                 }
             }

--- a/persistit/core/src/main/java/com/persistit/IOMeter.java
+++ b/persistit/core/src/main/java/com/persistit/IOMeter.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2011-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -264,7 +265,7 @@ class IOMeter implements IOMeterMXBean {
                 if (op == -1) {
                     break;
                 }
-                final String opName = op >= 0 && op < OPERATIONS.length ? OPERATIONS[op] : "??";
+                final String opName = op < OPERATIONS.length ? OPERATIONS[op] : "??";
                 final long time = is.readLong();
                 final int volumeHandle = is.readInt();
                 final long pageAddress = is.readLong();

--- a/persistit/core/src/main/java/com/persistit/Key.java
+++ b/persistit/core/src/main/java/com/persistit/Key.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -3264,7 +3265,7 @@ public final class Key implements Comparable<Object> {
             index = 0;
         for (int i = index; i < _size; i++) {
             if (_bytes[i] == 0) {
-                return i < _size ? i + 1 : -1;
+                return i + 1;
             }
         }
         // return index < _size ? _size : -1;
@@ -4008,8 +4009,6 @@ public final class Key implements Comparable<Object> {
             if (neg)
                 lowBits = -lowBits;
             for (int j = 0; j < 2 && index >= 0; j++) {
-                if (index < 0)
-                    break;
                 for (int k = 0; k < 4; k++) {
                     final int hundred = (int) (lowBits % 100);
                     final int bcd = (hundred / 10) * 16 + (hundred % 10);

--- a/persistit/core/src/main/java/com/persistit/KeyParser.java
+++ b/persistit/core/src/main/java/com/persistit/KeyParser.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -522,9 +523,7 @@ public class KeyParser {
                 _sb.append((char) c);
                 escape = false;
             } else {
-                if (c == '\\')
-                    escape = true;
-                else if (c == '\"') {
+                if (c == '\"') {
                     return true;
                 } else
                     _sb.append((char) c);

--- a/persistit/core/src/main/java/com/persistit/LongRecordHelper.java
+++ b/persistit/core/src/main/java/com/persistit/LongRecordHelper.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -114,10 +115,7 @@ class LongRecordHelper {
                 buffer = null;
 
                 if (count > MAX_LONG_RECORD_CHAIN) {
-                    if (count > MAX_LONG_RECORD_CHAIN) {
-                        corrupt("LONG_RECORD chain starting at " + startAtPage + " is too long");
-                    }
-
+                    corrupt("LONG_RECORD chain starting at " + startAtPage + " is too long");
                 }
             }
             value.setLongSize(rawSize);

--- a/persistit/core/src/main/java/com/persistit/TransactionPlayer.java
+++ b/persistit/core/src/main/java/com/persistit/TransactionPlayer.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -127,6 +128,7 @@ class TransactionPlayer {
             address = continuation.longValue();
             _support.read(address, TX.OVERHEAD);
             recordSize = TX.getLength(_support.getReadBuffer());
+            type = TX.getType(_support.getReadBuffer());
             if (recordSize < TX.OVERHEAD || recordSize > Transaction.TRANSACTION_BUFFER_SIZE + TX.OVERHEAD
                     || type != TX.TYPE) {
                 throw new CorruptJournalException("Transaction record at " + addressToString(address)

--- a/persistit/ui/src/main/java/com/persistit/ui/AdminUIBufferPanel.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/AdminUIBufferPanel.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -236,7 +237,7 @@ public class AdminUIBufferPanel extends AdminPanel implements AdminCommand {
 
             if (_bufferPoolIndex < 0)
                 _bufferPoolIndex = 0;
-            if (_bufferPoolIndex >= 0 && bufferPoolInfoArray != null && _bufferPoolIndex < bufferPoolInfoArray.length) {
+            if (bufferPoolInfoArray != null && _bufferPoolIndex < bufferPoolInfoArray.length) {
                 final int bufferSize = bufferPoolInfoArray[_bufferPoolIndex].getBufferSize();
                 _bufferInfoArrayModel.setInfoArray(management.getBufferInfoArray(bufferSize, _selectedTraversalType,
                         _selectedIncludeMask, _selectedExcludeMask));

--- a/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
- * 
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -217,7 +218,7 @@ public class ManagementTableModel extends AbstractTableModel {
             final TableColumnModel tcm = table.getColumnModel();
             final int count = tcm.getColumnCount();
             if (count > _displayedColumnCount) {
-                for (int i = _displayedColumnCount; --i >= count;) {
+                for (int i = count; --i >= _displayedColumnCount;) {
                     tcm.removeColumn(tcm.getColumn(i));
                 }
             }


### PR DESCRIPTION
## Summary

Resolves the 19 open `java/constant-comparison` CodeQL alerts: **2 real defects
fixed**, **12 provably-constant (dead) comparisons removed** in code
(behaviour-identical, so the alerts are cleared at the source), and **5 dismissed**
as `won't fix` (intentional defensive/readable code).

## Real bugs (2)

| Module | File | Defect |
|---|---|---|
| `persistit/ui` | `ManagementTableModel` | Column-removal loop `for (i = _displayedColumnCount; --i >= count;)` inside `if (count > _displayedColumnCount)` — body **never executed**, so surplus table columns were never removed. Bounds were swapped. |
| `json-schema/cli` | `Main` | Verbose validation tested `valid.length == 0` (a `boolean[1]`, always false) and never set the flag true → **"OK - Object is valid!" never printed**. Init flag to `true`, test `valid[0]`. |

## Dead / redundant comparisons removed (12, behaviour-identical)

| Module | File | Dead comparison |
|---|---|---|
| `persistit/core` | `TransactionPlayer` | Replay loop re-checked `type != TX.TYPE` without re-reading `type`. Now re-reads `type` per continuation record so the check is live and consistent with the `recordSize` check. |
| `persistit/core` | `LongRecordHelper` | `if (count > MAX_LONG_RECORD_CHAIN)` nested inside an identical one — flattened. |
| `persistit/core` | `KeyParser` | `else`-branch re-tested `if (c == '\\')`, unreachable there (backslash handled above). |
| `persistit/core` | `Key` | `return i < _size ? i + 1 : -1` → `i < _size` always true → `return i + 1`. |
| `persistit/core` | `Key` | Removed `if (index < 0) break;` inside a `for (…; index >= 0; …)` loop. |
| `commons/util` | `JsonValue` | Dropped `&& index >= 0` after the preceding `if (index < 0) throw`. |
| `commons/json-fluent` | `JsonValue` | Same `&& index >= 0` (legacy copy). |
| `persistit/ui` | `AdminUIBufferPanel` | Dropped `_bufferPoolIndex >= 0 &&` after the index is normalised to `0` two lines above. |
| `persistit/core` | `IOMeter` | Dropped `op >= 0 &&` after `if (op == -1) break`. |
| `persistit/core` | `FastIndex` | Removed vestigial `faultAt` var and its `if (faultAt < 0)` guards (assigned then immediately returned, never read). |
| `persistit/core` | `Buffer` | Removed a dead diagnostic-dump clamp `if (keep < TAILBLOCK_HDR_SIZE_DATA && keep > tbSize)` (never holds; fill loop already handles `keep > tbSize`). |

## Behaviour

Only two behaviours change, both to fix the bugs above (columns now removed; verbose
success now printed). Everything else is behaviour-identical removal of
provably-constant sub-expressions. `TransactionPlayer` now re-reads `type` on each
continuation record — a live re-validation that was previously dead; every record is
already type-validated in the first pass, so this only tightens defence-in-depth.

## Not in this PR (dismissed as `won't fix`, 5)

Intentional code where the constant sub-expression is deliberate:
`LongRecordHelper` and `Key.maxStorableKeySize` defensive assertions/clamps,
`Buffer` page-integrity bounds and a provable invariant on the hot key-search path,
and the explicit HTTP status-family range ladder in `Status`.

## Testing

`mvn -o -pl persistit/core,persistit/ui,commons/json-schema/cli,commons/util/util,commons/json-fluent compile` — all modules compile.
`commons/util` `JsonValueTest` + `JsonValueFunctionsTest` (96) and `json-fluent` `JsonValueTest` (5) pass, covering the `get(int)` change. (persistit unit tests are skipped in the offline build environment.)
