### PR TITLE
Widen int multiplications to long before overflow (CodeQL java/integer-multiplication-cast-to-long)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/JournalManagerBench.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManagerBench.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,12 +88,12 @@ public class JournalManagerBench {
     private void runTest() throws Exception {
         file = new File(ap.getStringValue("datapath"), "JManBench_TestFile");
         fc = new RandomAccessFile(file, "rw").getChannel();
-        preallocateFile(ap.getIntValue("prealloc") * 1024 * 1024);
+        preallocateFile(ap.getIntValue("prealloc") * 1024L * 1024);
         for (int i = 0; i < bytes.length; i++) {
             bytes[i] = (byte) ('-');
         }
         final int align = ap.getIntValue("align");
-        final long extension = ap.getIntValue("extension") * 1024 * 1024;
+        final long extension = ap.getIntValue("extension") * 1024L * 1024;
 
         final long start = System.nanoTime();
         final long expires = start + ap.getIntValue("duration") * NS_PER_S;

--- a/persistit/examples/SimpleTransaction/SimpleTransaction.java
+++ b/persistit/examples/SimpleTransaction/SimpleTransaction.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +105,7 @@ public class SimpleTransaction implements Runnable {
             System.out.println("Completed transactions: " + _committedTransactionCount);
             System.out.println("Failed transactions: " + _failedTransactionCount);
             System.out.println("Retried transactions: " + _rolledBackTransactionCount);
-            System.out.println("Average completed transactions rate: " + (_committedTransactionCount * 1000 / time)
+            System.out.println("Average completed transactions rate: " + (_committedTransactionCount * 1000L / time)
                     + " per second");
 
             int endingBalance = balance(accountEx);

--- a/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1285,7 +1286,7 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
         if (interval >= 0)
             _refreshInterval = interval;
         if (_refreshInterval > 0) {
-            _refreshTimer.schedule(_refreshTimerTask, 0, _refreshInterval * 1000);
+            _refreshTimer.schedule(_refreshTimerTask, 0, _refreshInterval * 1000L);
         } else {
             _refreshTimer.schedule(_refreshTimerTask, 0);
         }


### PR DESCRIPTION
## Summary

Resolves 4 `java/integer-multiplication-cast-to-long` CodeQL alerts. In each spot an
`int * int` product is computed in 32-bit arithmetic and only afterwards widened to
`long` (by assignment, a `long` parameter, or a `long`-context division), so a large
operand overflows *before* the widening. Forcing the multiplication into `long` with
an `L` suffix fixes it.

## Fixes

| Module | File | Change |
|---|---|---|
| `persistit/core` | `JournalManagerBench` | `prealloc * 1024 * 1024` → `1024L` (product passed to `preallocateFile(long)`) and `extension * 1024 * 1024` → `1024L` (assigned to a `long`) — MByte → byte-count conversions. |
| `persistit/examples` | `SimpleTransaction` | `_committedTransactionCount * 1000` → `1000L` before the divide by the `long` elapsed time; the committed count can exceed ~2.1M in a long run. |
| `persistit/ui` | `AdminUI` | `_refreshInterval * 1000` → `1000L`, passed as the `long` period of `Timer.schedule`. |

## Behaviour

Unchanged for in-range inputs — the products are identical; only the silent 32-bit
overflow at large inputs is removed. All three are benchmark / example / admin-UI
classes, not core data paths.

## Testing

`mvn -o -pl persistit/core,persistit/ui -am compile` — BUILD SUCCESS.
`SimpleTransaction` is an Ant example (no Maven module); the one-character change is
compile-trivial.
