### PR TITLE
Make the shared Key.SDF date formatter thread-safe (CodeQL java/thread-unsafe-dateformat)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Key.java
+++ b/persistit/core/src/main/java/com/persistit/Key.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -504,14 +505,19 @@ public final class Key implements Comparable<Object> {
     public final static EdgeValue AFTER = new EdgeValue(true);
 
     /**
-     * The <code>java.text.SimpleDateFormat</code> used in formatting
+     * A thread-local <code>java.text.SimpleDateFormat</code> used in formatting
      * <code>Date</code>- valued keys in the {@link #decodeDisplayable} methods.
      * This format also governs the conversion of dates for the
      * <code>toString</code> method. This format provides millisecond resolution
      * so that the precise stored representation of a date used as a key can be
      * represented exactly, but readably, in the displayable version.
+     * <p>
+     * <code>SimpleDateFormat</code> is not thread-safe, so the instance is held
+     * in a {@link ThreadLocal}; call {@link ThreadLocal#get()} to obtain the
+     * per-thread formatter, e.g. <code>SDF.get().format(date)</code>.
      */
-    public final static SimpleDateFormat SDF = new SimpleDateFormat("yyyyMMddHHmmss.SSSZ");
+    public final static ThreadLocal<SimpleDateFormat> SDF = ThreadLocal
+            .withInitial(() -> new SimpleDateFormat("yyyyMMddHHmmss.SSSZ"));
 
     /**
      * Displayable prefix for boolean values (optional for input, implied and
@@ -3139,7 +3145,7 @@ public final class Key implements Comparable<Object> {
 
         else if (cl == Date.class) {
             Util.append(sb, PREFIX_DATE);
-            Util.append(sb, SDF.format(decodeDate()));
+            Util.append(sb, SDF.get().format(decodeDate()));
         }
 
         else if (cl == byte[].class) {

--- a/persistit/core/src/main/java/com/persistit/KeyParser.java
+++ b/persistit/core/src/main/java/com/persistit/KeyParser.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -293,7 +294,7 @@ public class KeyParser {
                     }
                 } else if (matchExactString(Key.PREFIX_DATE) || matchExactString(Key.PREFIX_DATE0)) {
                     if (matchNumber(true, true)) {
-                        key.append(Key.SDF.parse(_sb.toString()));
+                        key.append(Key.SDF.get().parse(_sb.toString()));
                         result = true;
                     }
                 } else if (matchExactString(Key.PREFIX_BYTE_ARRAY)) {

--- a/persistit/core/src/main/java/com/persistit/Value.java
+++ b/persistit/core/src/main/java/com/persistit/Value.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1566,7 +1567,7 @@ public final class Value {
           sb.append("...");
       } else if (cl == Date.class) {
         appendParenthesizedFriendlyClassName(sb, cl);
-        sb.append(Key.SDF.format((Date) value));
+        sb.append(Key.SDF.get().format((Date) value));
       } else if (value instanceof Number) {
         sb.append('(');
         sb.append(className.startsWith("java.lang.") ? className.substring(10) : className);

--- a/persistit/ui/src/main/java/com/persistit/ui/ValueInspectorTreeNode.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/ValueInspectorTreeNode.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,7 +157,7 @@ class ValueInspectorTreeNode implements TreeNode {
                 sb.append('\"');
             } else if (object instanceof Date) {
                 sb.append(" = ");
-                sb.append(Key.SDF.format((Date) object));
+                sb.append(Key.SDF.get().format((Date) object));
             } else if (type == Boolean.class || type == Byte.class || type == Short.class || type == Character.class
                     || type == Integer.class || type == Long.class || type == Float.class || type == Double.class
                     || type == BigInteger.class || type == BigDecimal.class) {


### PR DESCRIPTION
## Summary

Resolves the `java/thread-unsafe-dateformat` CodeQL alert on `Key.SDF`.

`Key.SDF` was a `public final static SimpleDateFormat`. `SimpleDateFormat`
is **not thread-safe** — concurrent `format()` / `parse()` calls mutate its
internal `Calendar` and can produce garbled text, wrong dates, or
`ArrayIndexOutOfBoundsException`. This single shared instance is reachable
from several classes that run on multiple threads:

- `Key.decodeDisplayable` / `Key.toString`
- `Value.toString`
- `KeyParser` (`parse`, date keys)
- `com.persistit.ui.ValueInspectorTreeNode` (Swing)

## Fix

Wrap the formatter in a `ThreadLocal` so each thread gets its own instance:

```java
public final static ThreadLocal<SimpleDateFormat> SDF = ThreadLocal
        .withInitial(() -> new SimpleDateFormat("yyyyMMddHHmmss.SSSZ"));
```

and update the four call sites to `Key.SDF.get().format(...)` /
`Key.SDF.get().parse(...)`.

The date pattern is unchanged, so formatting and parsing behaviour is
identical for every input; only the shared mutable state is removed.

## Note

`Key.SDF` is a `public` field, so its compile-time type changes from
`SimpleDateFormat` to `ThreadLocal<SimpleDateFormat>`. All in-repo callers
are updated in this PR. Any external caller would replace `Key.SDF.format(d)`
with `Key.SDF.get().format(d)`.

The other, `private` static `SimpleDateFormat` fields in the tree
(`JournalTool`, `VolumeHeader`, `CheckpointManager`, and the `AbstractSuite`
test) were **not** flagged by CodeQL and are left unchanged.

## Testing

`mvn -o -pl persistit/core,persistit/ui -am compile` — BUILD SUCCESS.
