### PR TITLE
Handle uncaught NumberFormatException at 20 parse sites (CodeQL java/uncaught-number-format-exception)

### DIFF
--- a/commons/audit/core/src/main/java/org/forgerock/audit/events/handlers/writers/AsynchronousTextWriter.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/events/handlers/writers/AsynchronousTextWriter.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2006-2008 Sun Microsystems, Inc.
  *      Portions Copyright 2013-2015 ForgeRock AS.
+ *      Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.events.handlers.writers;
 
@@ -42,8 +43,24 @@ import static org.forgerock.audit.batch.CommonAuditBatchConfiguration.POLLING_TI
 public class AsynchronousTextWriter implements TextWriter {
 
     private static final Logger logger = LoggerFactory.getLogger(AsynchronousTextWriter.class);
+    /** System property overriding the default queue capacity. */
+    private static final String CAPACITY_PROPERTY =
+            "org.forgerock.audit.events.handlers.writers.AsynchronousTextWriter.CAPACITY";
+    /** Default queue capacity used when {@link #CAPACITY_PROPERTY} is unset or invalid. */
+    private static final int DEFAULT_CAPACITY = 32000;
     /** Maximum number of messages that can be queued before producers start to block. */
-    private static final int CAPACITY = Integer.parseInt(System.getProperty("org.forgerock.audit.events.handlers.writers.AsynchronousTextWriter.CAPACITY","32000"));
+    private static final int CAPACITY = readCapacity();
+
+    private static int readCapacity() {
+        final String value = System.getProperty(CAPACITY_PROPERTY, String.valueOf(DEFAULT_CAPACITY));
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            logger.warn("Invalid value '{}' for system property {}; using default {}.",
+                    value, CAPACITY_PROPERTY, DEFAULT_CAPACITY);
+            return DEFAULT_CAPACITY;
+        }
+    }
 
     /** The wrapped Text Writer. */
     private final TextWriter writer;

--- a/commons/audit/handler-elasticsearch/src/main/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandler.java
+++ b/commons/audit/handler-elasticsearch/src/main/java/org/forgerock/audit/handlers/elasticsearch/ElasticsearchAuditEventHandler.java
@@ -54,6 +54,7 @@ import org.forgerock.http.protocol.Response;
 import org.forgerock.http.protocol.Responses;
 import org.forgerock.http.spi.Loader;
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.CountPolicy;
 import org.forgerock.json.resource.InternalServerErrorException;
 import org.forgerock.json.resource.NotFoundException;
@@ -199,7 +200,11 @@ public class ElasticsearchAuditEventHandler extends AuditEventHandlerBase implem
         if (query.getPagedResultsOffset() != 0) {
             offset = query.getPagedResultsOffset();
         } else if (query.getPagedResultsCookie() != null) {
-            offset = Integer.valueOf(query.getPagedResultsCookie());
+            try {
+                offset = Integer.parseInt(query.getPagedResultsCookie());
+            } catch (final NumberFormatException e) {
+                return new BadRequestException("Invalid paged results cookie", e).asPromise();
+            }
         } else {
             offset = DEFAULT_OFFSET;
         }

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -168,9 +168,9 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
             throw new AuthenticationException("Can't use both " + TOKEN_IDLE_TIME_IN_MINUTES_CLAIM_KEY
                     + " setting and the " + TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY + " setting.");
         } else if (!isEmpty(tokenIdleTimeMinutes)) {
-            this.tokenIdleTime = Integer.parseInt(tokenIdleTimeMinutes) * 60;
+            this.tokenIdleTime = parseIntSetting(TOKEN_IDLE_TIME_IN_MINUTES_CLAIM_KEY, tokenIdleTimeMinutes) * 60;
         } else if (!isEmpty(tokenIdleTimeSeconds)) {
-            this.tokenIdleTime = Integer.parseInt(tokenIdleTimeSeconds);
+            this.tokenIdleTime = parseIntSetting(TOKEN_IDLE_TIME_IN_SECONDS_CLAIM_KEY, tokenIdleTimeSeconds);
         } else {
             this.tokenIdleTime = 0;
         }
@@ -180,9 +180,9 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
             throw new AuthenticationException("Can't use both the " + MAX_TOKEN_LIFE_IN_MINUTES_KEY
                     + " setting and the " + MAX_TOKEN_LIFE_IN_SECONDS_KEY + " setting.");
         } else if (!isEmpty(maxTokenLifeMinutes)) {
-            this.maxTokenLife = Integer.parseInt(maxTokenLifeMinutes) * 60;
+            this.maxTokenLife = parseIntSetting(MAX_TOKEN_LIFE_IN_MINUTES_KEY, maxTokenLifeMinutes) * 60;
         } else if (!isEmpty(maxTokenLifeSeconds)) {
-            this.maxTokenLife = Integer.parseInt(maxTokenLifeSeconds);
+            this.maxTokenLife = parseIntSetting(MAX_TOKEN_LIFE_IN_SECONDS_KEY, maxTokenLifeSeconds);
         } else {
             this.maxTokenLife = 0;
         }
@@ -202,6 +202,14 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
         }
         this.signingHandler = new HmacSigningHandler(signingKey);
         Arrays.fill(signingKey, (byte) 0);
+    }
+
+    private static int parseIntSetting(final String settingName, final String value) throws AuthenticationException {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            throw new AuthenticationException("The " + settingName + " setting must be an integer, but was: " + value);
+        }
     }
 
     /**

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/header/Warning.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/header/Warning.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.header;
@@ -150,7 +151,12 @@ public class Warning {
     public static Warning valueOf(final String value) {
         final Matcher m = PATTERN.matcher(value);
         if (m.matches()) {
-            final int code = Integer.parseInt(m.group(1));
+            final int code;
+            try {
+                code = Integer.parseInt(m.group(1));
+            } catch (final NumberFormatException e) {
+                return null;
+            }
             final String agent = m.group(2);
             final String tail = m.group(3);
             final String text;

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSet.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSet.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.jose.exceptions.JwtRuntimeException;
 import org.forgerock.json.jose.utils.IntDate;
 import org.forgerock.json.jose.utils.StringOrURI;
 
@@ -397,7 +398,11 @@ public class JwtClaimsSet extends JWObject implements Payload {
             if (isValueOfType(value, Number.class)) {
                 setExpirationTime(((Number) value).longValue());
             } else if (isValueOfType(value, String.class)) {
-            	setExpirationTime(Long.parseLong((String)value));
+                try {
+                    setExpirationTime(Long.parseLong((String) value));
+                } catch (final NumberFormatException e) {
+                    throw new JwtRuntimeException("Expiration time claim (exp) is not a valid number: " + value, e);
+                }
             } else {
                 checkValueIsOfType(value, Date.class);
                 setExpirationTime((Date) value);

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestIntegerSchema.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestIntegerSchema.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.api.jackson;
@@ -194,6 +195,10 @@ class CrestIntegerSchema extends IntegerSchema implements CrestReadWritePolicies
 
     @Override
     public void setExample(String example) {
-        this.example = Long.valueOf(example);
+        try {
+            this.example = Long.valueOf(example);
+        } catch (final NumberFormatException e) {
+            throw new ValidationException("Example value is not a valid integer: " + example);
+        }
     }
 }

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -68,10 +69,15 @@ public final class MemoryBackend implements CollectionResourceProvider {
             this.lastResultIndex = lastResultIndex;
         }
 
-        static Cookie valueOf(String base64) {
+        static Cookie valueOf(String base64) throws ResourceException {
             final String decoded = new String(Base64.decode(base64));
             final String[] split = decoded.split(":");
-            final int lastOffset = Integer.parseInt(split[0]);
+            final int lastOffset;
+            try {
+                lastOffset = Integer.parseInt(split[0]);
+            } catch (final NumberFormatException e) {
+                throw new BadRequestException("Invalid paged results cookie", e);
+            }
             final List<SortKey> sortKeys = new ArrayList<>();
             final String[] splitKeys = split[1].split(",");
 
@@ -596,7 +602,11 @@ public final class MemoryBackend implements CollectionResourceProvider {
                     return new BadRequestException("Cookies and offsets are mutually exclusive").asPromise();
                 }
 
-                firstResultIndex = Cookie.valueOf(pagedResultsCookie).getLastResultIndex();
+                try {
+                    firstResultIndex = Cookie.valueOf(pagedResultsCookie).getLastResultIndex();
+                } catch (final ResourceException e) {
+                    return e.asPromise();
+                }
             } else {
                 if (request.getPagedResultsOffset() > 0) {
                     firstResultIndex = request.getPagedResultsOffset();

--- a/commons/util/util/src/main/java/org/forgerock/util/query/QueryFilterParser.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/query/QueryFilterParser.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.util.query;
@@ -217,10 +218,18 @@ public abstract class QueryFilterParser<F> {
                     assertionValue = Boolean.parseBoolean(nextToken);
                 } else if (nextToken.indexOf('.') >= 0) {
                     // Floating point number.
-                    assertionValue = Double.parseDouble(nextToken);
+                    try {
+                        assertionValue = Double.parseDouble(nextToken);
+                    } catch (final NumberFormatException e) {
+                        return valueOfIllegalArgument(tokenizer);
+                    }
                 } else {
                     // Must be an integer.
-                    assertionValue = Long.parseLong(nextToken);
+                    try {
+                        assertionValue = Long.parseLong(nextToken);
+                    } catch (final NumberFormatException e) {
+                        return valueOfIllegalArgument(tokenizer);
+                    }
                 }
                 try {
                     return comparisonFilter(pointer, operator, assertionValue);

--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2011-2012 Akiban Technologies, Inc.
  * Copyright 2015 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1261,7 +1262,11 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
     static long fileToGeneration(final File file) {
         final Matcher matcher = PATH_PATTERN.matcher(file.getName());
         if (matcher.matches()) {
-            return Long.parseLong(matcher.group(2));
+            try {
+                return Long.parseLong(matcher.group(2));
+            } catch (final NumberFormatException e) {
+                return -1;
+            }
         } else {
             return -1;
         }

--- a/persistit/core/src/main/java/com/persistit/KeyParser.java
+++ b/persistit/core/src/main/java/com/persistit/KeyParser.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -535,7 +536,12 @@ public class KeyParser {
     private int unicode() {
         if (_index + 4 > _end)
             return -1;
-        final int u = Integer.parseInt(_source.substring(_index, _index + 4), 16);
+        final int u;
+        try {
+            u = Integer.parseInt(_source.substring(_index, _index + 4), 16);
+        } catch (final NumberFormatException e) {
+            return -1;
+        }
         _index += 4;
         return u;
     }

--- a/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -705,7 +706,7 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
         JComponent wrappedComponent = component;
         if (component instanceof JTextField) {
             final JTextField textField = (JTextField) component;
-            textField.setColumns(Integer.parseInt(widthStr));
+            textField.setColumns(parseDimension("width", widthStr));
             textField.setHorizontalAlignment(alignment.equals("R") ? SwingConstants.TRAILING
                     : alignment.equals("C") ? SwingConstants.CENTER : SwingConstants.LEADING);
             textField.setEditable(false);
@@ -713,8 +714,8 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
             textField.setBackground(Color.white);
         } else if (component instanceof JTextArea) {
             final JTextArea textArea = (JTextArea) component;
-            textArea.setColumns(Integer.parseInt(widthStr));
-            textArea.setRows(Integer.parseInt(heightStr));
+            textArea.setColumns(parseDimension("width", widthStr));
+            textArea.setRows(parseDimension("height", heightStr));
             textArea.setEditable(false);
             textArea.setEnabled(true);
             textArea.setBackground(Color.white);
@@ -734,6 +735,14 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
 
         component.setMinimumSize(component.getPreferredSize());
         return component;
+    }
+
+    private static int parseDimension(final String name, final String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid " + name + " in component specification: " + value, e);
+        }
     }
 
     AdminAction createAction(final AdminCommand command, final String specification) {

--- a/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
@@ -113,13 +113,23 @@ public class ManagementTableModel extends AbstractTableModel {
         for (int index = 0; index < columnSpecs.length; index++) {
             final StringTokenizer st = new StringTokenizer(columnSpecs[index], ":");
             final String methodName = st.nextToken();
-            final int width = Integer.parseInt(st.nextToken());
+            final int width;
+            try {
+                width = Integer.parseInt(st.nextToken());
+            } catch (final NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid width in column specification: " + columnSpecs[index], e);
+            }
             final String flags = st.nextToken();
             final String header = st.nextToken();
             String rendererName = null;
             int minWidth = width / 2;
             if (st.hasMoreTokens()) {
-                minWidth = Integer.parseInt(st.nextToken());
+                try {
+                    minWidth = Integer.parseInt(st.nextToken());
+                } catch (final NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            "Invalid minimum width in column specification: " + columnSpecs[index], e);
+                }
             }
             if (st.hasMoreTokens()) {
                 rendererName = st.nextToken();

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
@@ -18,7 +18,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions Copyrighted 2018-2025 3A Systems, LLC
+ * Portions Copyrighted 2018-2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -96,8 +96,17 @@ public class RhinoScriptEngine extends AbstractScriptEngine {
         this.factory = factory;
         final JsonValue jsonValueConfig = new JsonValue(configuration);
         initDebugListener(jsonValueConfig.get(CONFIG_DEBUG_PROPERTY).defaultTo(null).asString());
-        minimumRecompilationInterval = Long.valueOf(
-                jsonValueConfig.get(CONFIG_RECOMPILE_MINIMUM_INTERVAL_PROPERTY).defaultTo("-1").asString());
+        final String recompileInterval =
+                jsonValueConfig.get(CONFIG_RECOMPILE_MINIMUM_INTERVAL_PROPERTY).defaultTo("-1").asString();
+        long minimumRecompilationIntervalValue;
+        try {
+            minimumRecompilationIntervalValue = Long.parseLong(recompileInterval);
+        } catch (final NumberFormatException e) {
+            logger.warn("Invalid {} configuration value '{}'; using default -1.",
+                    CONFIG_RECOMPILE_MINIMUM_INTERVAL_PROPERTY, recompileInterval);
+            minimumRecompilationIntervalValue = -1;
+        }
+        minimumRecompilationInterval = minimumRecompilationIntervalValue;
         scriptExceptionGenerator = jsonValueConfig.get(CONFIG_EXCEPTION_DEBUG_INFO).defaultTo(true).asBoolean()
                 ? DEBUG_SCRIPT_EXCEPTION_GENERATOR
                 : NON_DEBUG_SCRIPT_EXCEPTION_GENERATOR;


### PR DESCRIPTION
## Summary

Resolves all 20 `java/uncaught-number-format-exception` CodeQL alerts (11 modules).

Each flagged site parsed an `int`/`long`/`double` from a value that could reach
it malformed, with no surrounding `catch`, so bad input escaped as a raw
`NumberFormatException`. Every site is now routed to the failure mode that
already matches its method contract, so callers get a controlled result rather
than a leaking runtime exception. **Behaviour is unchanged for valid input.**

## Fixes by category

### Untrusted / client input → proper error
| File | Change |
|---|---|
| `MemoryBackend` | Invalid `pagedResultsCookie` → `BadRequestException` (HTTP 400) instead of 500; `Cookie.valueOf` now declares `throws ResourceException` and the caller returns `e.asPromise()`. |
| `ElasticsearchAuditEventHandler` | Invalid `pagedResultsCookie` → `BadRequestException.asPromise()` (400) instead of 500. |
| `QueryFilterParser` | Non-numeric assertion value → the parser's existing `valueOfIllegalArgument(tokenizer)` result. |
| `JwtClaimsSet` | Non-numeric `exp` string claim → `JwtRuntimeException` (the class's own type-check exception) with a clear message. |

### Configuration input → clear message / documented default
| File | Change |
|---|---|
| `AbstractJwtSessionModule` | Token-idle-time / max-token-life settings parsed via a helper that throws `AuthenticationException` naming the bad setting. |
| `AsynchronousTextWriter` | Invalid `CAPACITY` system property → warn + fall back to default `32000` (no longer fails class init). |
| `RhinoScriptEngine` | Invalid recompile-interval config → warn + fall back to documented default `-1`. |
| `CrestIntegerSchema` | Non-integer `example` → `ValidationException` (the Crest schema idiom). |

### Sentinel-returning parsers → existing sentinel
| File | Change |
|---|---|
| `KeyParser.unicode()` | Malformed `\uXXXX` escape → the method's existing `-1` "cannot parse" sentinel. |
| `JournalManager.fileToGeneration()` | Non-numeric generation → the method's existing `-1` (matches the no-match branch). |
| `Warning.valueOf()` | Non-numeric warn-code → `null`, matching the documented "null if it could not be parsed" contract. |

### Internal, developer-controlled specs → loud but described failure
| File | Change |
|---|---|
| `ManagementTableModel.setup()` | Malformed column spec → `IllegalArgumentException` naming the offending spec. |
| `AdminUI.addLabeledField()` | Malformed component width/height spec → `IllegalArgumentException` naming the value. |

## Notes

`Warning.valueOf` (`[0-9]{3}`) and `JournalManager.fileToGeneration` (`\d{12}`)
parse regex-guaranteed digit groups that cannot actually overflow today; the
guards route to each method's existing failure return, so they are cheap
hardening against future regex drift rather than dead code.

## Testing

`mvn -o -am compile` across all eleven affected modules — BUILD SUCCESS.
