### PR TITLE
Use Objects.equals instead of hand-rolled String == comparison (CodeQL java/reference-equality-on-strings)

### DIFF
--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Responses.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Responses.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -250,19 +251,9 @@ public final class Responses {
                 return true;
             } else if (obj instanceof ResourceResponseImpl) {
                 final ResourceResponseImpl that = (ResourceResponseImpl) obj;
-                return isEqual(id, that.id) && isEqual(revision, that.revision);
+                return Objects.equals(id, that.id) && Objects.equals(revision, that.revision);
             } else {
                 return false;
-            }
-        }
-
-        private boolean isEqual(final String s1, final String s2) {
-            if (s1 == s2) {
-                return true;
-            } else if (s1 == null || s2 == null) {
-                return false;
-            } else {
-                return s1.equals(s2);
             }
         }
 


### PR DESCRIPTION
## Summary

Resolves the single `java/reference-equality-on-strings` CodeQL alert in
`Responses.java`.

`ResourceResponseImpl.equals()` delegated to a private `isEqual(String, String)`
helper whose first line was a `s1 == s2` reference comparison. The reference
check was an intentional fast-path (and both-`null` shortcut) with the real
value comparison delegated to `s1.equals(s2)` — so the code was correct, but:

- CodeQL flags the `String == String`, and
- the helper is a hand-rolled reimplementation of `java.util.Objects.equals`.

## Fix

Replace the two `isEqual(...)` calls with `Objects.equals(...)` (already
imported) and delete the helper:

```java
return Objects.equals(id, that.id) && Objects.equals(revision, that.revision);
```

Behaviour is identical — `Objects.equals(a, b)` performs the same
`a == b || (a != null && a.equals(b))` null-safe comparison, including the
same reference fast-path and both-`null` handling.

## Testing

`mvn -o -pl commons/rest/json-resource -am compile` — BUILD SUCCESS.
