### PR TITLE
Widen volumeHandle to long before shifting by 48 (CodeQL java/lshift-larger-than-type-width)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/IOMeter.java
+++ b/persistit/core/src/main/java/com/persistit/IOMeter.java
@@ -280,7 +280,7 @@ class IOMeter implements IOMeterMXBean {
                 if (analyzePages
                         && (op == WRITE_PAGE_TO_JOURNAL || op == READ_PAGE_FROM_JOURNAL || op == READ_PAGE_FROM_VOLUME
                                 || op == COPY_PAGE_FROM_JOURNAL || op == COPY_PAGE_TO_VOLUME || op == EVICT_PAGE_FROM_POOL)) {
-                    final long handle = (volumeHandle << 48) + pageAddress;
+                    final long handle = ((long) volumeHandle << 48) + pageAddress;
                     List<Event> list = events.get(handle);
                     if (list == null) {
                         list = new ArrayList<Event>(2);


### PR DESCRIPTION
## Summary

Resolves the single `java/lshift-larger-than-type-width` CodeQL alert in
`IOMeter.java`.

`IOMeter.dump()` builds a composite key that groups journal events by
`(volumeHandle, pageAddress)`:

```java
final int volumeHandle = is.readInt();
final long pageAddress = is.readLong();
...
final long handle = (volumeHandle << 48) + pageAddress;   // bug
```

`volumeHandle` is an `int`, and Java masks an `int` shift distance to its low
5 bits, so `<< 48` is actually evaluated as `<< (48 & 31)` = `<< 16` in 32-bit
arithmetic and only then widened to `long`. As a result:

- the volume handle lands in bits 16–47 instead of 48+, and
- `volumeHandle << 16` can overflow `int`,

so events for different volumes/pages can collide on the same `HashMap` key.

## Fix

Cast to `long` before the shift so it is performed in 64 bits:

```java
final long handle = ((long) volumeHandle << 48) + pageAddress;
```

This only affects the `-a` (analyze pages) mode of the journal-dump diagnostic
utility; it is not on a data path.

## Testing

`mvn -o -pl persistit/core -am compile` — BUILD SUCCESS.
