### PR TITLE
Declare equals/hashCode consistent with compareTo (CodeQL java/inconsistent-compareto-and-equals)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/BufferPool.java
+++ b/persistit/core/src/main/java/com/persistit/BufferPool.java
@@ -1338,6 +1338,22 @@ public class BufferPool {
 
         }
 
+        /**
+         * Equality is defined by the same (volumeId, page) ordering key used by
+         * {@link #compareTo(BufferHolder)}, so that {@code equals} stays
+         * consistent with the natural ordering.
+         */
+        @Override
+        public boolean equals(final Object object) {
+            return this == object
+                    || (object instanceof BufferHolder && compareTo((BufferHolder) object) == 0);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(_volumeId) * 31 + Long.hashCode(_page);
+        }
+
         @Override
         public String toString() {
             final Buffer buffer = _buffer;

--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -2156,6 +2157,22 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
                 return ts.isCommitted() ? -1 : ts.getStartTimestamp() < _startTimestamp ? 1
                         : ts.getStartTimestamp() > _startTimestamp ? -1 : 0;
             }
+        }
+
+        /**
+         * Equality is kept consistent with {@link #compareTo(TransactionMapItem)}:
+         * two items are equal exactly when they order equally (same commit
+         * timestamp for committed items, otherwise same start timestamp).
+         */
+        @Override
+        public boolean equals(final Object object) {
+            return this == object
+                    || (object instanceof TransactionMapItem && compareTo((TransactionMapItem) object) == 0);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(isCommitted() ? _commitTimestamp : _startTimestamp);
         }
 
         final static Comparator<TransactionMapItem> TRANSACTION_MAP_ITEM_COMPARATOR = new Comparator<TransactionMapItem>() {

--- a/persistit/core/src/main/java/com/persistit/TreeBuilder.java
+++ b/persistit/core/src/main/java/com/persistit/TreeBuilder.java
@@ -247,6 +247,24 @@ public class TreeBuilder {
                 return _key.compareTo(node._key);
         }
 
+        /**
+         * Equality is kept consistent with {@link #compareTo(Node)}: two nodes
+         * are equal exactly when they order equally (same tree and key, or both
+         * with no tree).
+         */
+        @Override
+        public boolean equals(final Object object) {
+            return this == object || (object instanceof Node && compareTo((Node) object) == 0);
+        }
+
+        @Override
+        public int hashCode() {
+            // Consistent with compareTo: equal nodes share the same tree
+            // instance (or both have none), so the tree's identity hash yields
+            // equal hash codes for equal nodes.
+            return _tree == null ? 0 : System.identityHashCode(_tree);
+        }
+
         @Override
         public String toString() {
             Node n = this;


### PR DESCRIPTION
## Summary

Resolves all three open `java/inconsistent-compareto-and-equals` CodeQL alerts
in the persistit engine. Each flagged class implements `Comparable`/`compareTo`
but inherited `Object.equals`, so `equals` and `compareTo` could be
inconsistent:

| Class | `compareTo` orders by | Used in |
|---|---|---|
| `BufferPool.BufferHolder` | `volumeId`, `page` | `Arrays.sort` |
| `JournalManager.TransactionMapItem` | commit / start timestamp | `TreeSet`, sorted `List` |
| `TreeBuilder.Node` | tree order, `key` | `TreeMap<Node, Node>` |

## Why it is safe

None of these types is currently compared through `equals`/`hashCode`:

- the sorted collections (`TreeMap`, `TreeSet`, `Arrays.sort`,
  `Collections.sort`) all use `compareTo`, not `equals`;
- the types are never placed in a hash collection keyed by themselves
  (`TransactionMapItem` is only a **value** in a `HashMap<Long, …>`), and
- there is no `contains` / `indexOf` / `remove(Object)` call that would invoke
  `equals` on them.

So the inconsistency was latent rather than an active bug, but it is exactly
the trap this rule guards against for future callers.

## Fix

For each class, declare `equals` and `hashCode` consistent with the existing
`compareTo`:

- `equals(o)` returns true iff `o` is the same reference or `compareTo(o) == 0`;
- `hashCode` is derived from the same ordering key
  (`(volumeId, page)`; commit-or-start timestamp; the tree instance for a
  `Node`).

Because nothing relied on the inherited identity `equals`, behaviour is
unchanged for every existing usage.

Also adds the missing `Portions Copyrighted 2026 3A Systems, LLC` header line
to `JournalManager.java` (`TreeBuilder.java` and `BufferPool.java` already
carry it).

## Testing

`mvn -o -pl persistit/core -am compile` — BUILD SUCCESS.
