### PR TITLE
Check ignored error status of I/O calls (CodeQL java/ignored-error-status-of-call)

### DIFF
--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/DerValue.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/DerValue.java
@@ -1,4 +1,4 @@
-//@Checkstyle:ignoreFor 29
+//@Checkstyle:ignoreFor 30
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -26,12 +26,14 @@
  * $Id: DerValue.java,v 1.2 2008/06/25 05:42:07 qcheng Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.jaspi.modules.iwa.wdsso;
 
 import static java.lang.Integer.toHexString;
 
 import java.io.ByteArrayInputStream;
+import java.util.Arrays;
 
 /**
  * A dedicated implementation of handling <code>ASN1/DER</code> for the
@@ -88,7 +90,13 @@ public class DerValue {
         tag = (byte) input.read();
         length = getLength(input);
         data = new byte[length];
-        input.read(data, 0, length);
+        final int read = input.read(data, 0, length);
+        if (read > 0 && read < length) {
+            // Truncated DER value: keep only the bytes actually read so that
+            // callers do not treat uninitialised trailing bytes as content.
+            length = read;
+            data = Arrays.copyOf(data, read);
+        }
     }
 
     private int getLength(ByteArrayInputStream input) {

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
@@ -1,4 +1,4 @@
-//@Checkstyle:ignoreFor 29
+//@Checkstyle:ignoreFor 30
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -26,6 +26,7 @@
  * $Id: WindowsDesktopSSO.java,v 1.7 2009/07/28 19:40:45 beomsuk Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.jaspi.modules.iwa.wdsso;
@@ -285,8 +286,8 @@ public class WDSSO {
 
         // check for SPNEGO OID
         byte[] oidArray = new byte[SPNEGO_OID.length];
-        tmpInput.read(oidArray, 0, oidArray.length);
-        if (Arrays.equals(oidArray, SPNEGO_OID)) {
+        final int oidRead = tmpInput.read(oidArray, 0, oidArray.length);
+        if (oidRead == oidArray.length && Arrays.equals(oidArray, SPNEGO_OID)) {
             tmpToken = new DerValue(tmpInput);
 
             // 0xa0 indicates an init token(NegTokenInit); 0xa1 indicates an
@@ -323,8 +324,8 @@ public class WDSSO {
             for (; i < oidArray.length; i++) {
                 krb5Oid[i] = oidArray[i];
             }
-            tmpInput.read(krb5Oid, i, krb5Oid.length - i);
-            if (!Arrays.equals(krb5Oid, KERBEROS_V5_OID)) {
+            final int krb5Read = tmpInput.read(krb5Oid, i, krb5Oid.length - i);
+            if (krb5Read != krb5Oid.length - i || !Arrays.equals(krb5Oid, KERBEROS_V5_OID)) {
                 LOG.debug("IWA WDSSO: Kerberos V5 OID not found in the Auth Token");
                 token = null;
             } else {

--- a/persistit/core/src/main/java/com/persistit/BackupTask.java
+++ b/persistit/core/src/main/java/com/persistit/BackupTask.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -260,8 +261,10 @@ public class BackupTask extends Task {
             final String candidate = k == 0 ? file.getAbsolutePath() + "~" : file.getAbsoluteFile() + "~" + k;
             final File newFile = new File(candidate);
             if (!newFile.exists()) {
-                file.renameTo(newFile);
-                return;
+                if (file.renameTo(newFile)) {
+                    return;
+                }
+                throw new IOException("Unable to rename file " + file + " to " + newFile);
             }
         }
         throw new IOException("Unable to rename file " + file);

--- a/persistit/core/src/main/java/com/persistit/IOMeter.java
+++ b/persistit/core/src/main/java/com/persistit/IOMeter.java
@@ -452,7 +452,14 @@ class IOMeter implements IOMeterMXBean {
         } else {
             final IOMeter ioMeter = new IOMeter();
             final DataInputStream is = new DataInputStream(new BufferedInputStream(new FileInputStream(fileName)));
-            is.skip(skip * DUMP_RECORD_LENGTH);
+            long toSkip = skip * DUMP_RECORD_LENGTH;
+            while (toSkip > 0) {
+                final long skipped = is.skip(toSkip);
+                if (skipped <= 0) {
+                    break;
+                }
+                toSkip -= skipped;
+            }
             ioMeter.dump(is, count == 0 ? Integer.MAX_VALUE : count, ap.isFlag('a'));
             is.close();
         }

--- a/persistit/core/src/main/java/com/persistit/StreamLoader.java
+++ b/persistit/core/src/main/java/com/persistit/StreamLoader.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -136,9 +137,9 @@ public class StreamLoader extends Task {
             final int elisionCount = _dis.readShort();
             final int valueSize = _dis.readInt();
             _value.ensureFit(valueSize);
-            _dis.read(_key.getEncodedBytes(), elisionCount, keySize - elisionCount);
+            _dis.readFully(_key.getEncodedBytes(), elisionCount, keySize - elisionCount);
             _key.setEncodedSize(keySize);
-            _dis.read(_value.getEncodedBytes(), 0, valueSize);
+            _dis.readFully(_value.getEncodedBytes(), 0, valueSize);
             _value.setEncodedSize(valueSize);
             handler.handleDataRecord(_key, _value);
             _dataRecordCount++;

--- a/persistit/core/src/main/java/com/persistit/Value.java
+++ b/persistit/core/src/main/java/com/persistit/Value.java
@@ -31,6 +31,7 @@ import com.persistit.exception.PersistitException;
 import com.persistit.util.Debug;
 import com.persistit.util.Util;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.NotActiveException;
@@ -4891,12 +4892,16 @@ public final class Value {
 
     @Override
     public void readFully(final byte[] b) throws IOException {
-      read(b, 0, b.length);
+      readFully(b, 0, b.length);
     }
 
     @Override
     public void readFully(final byte[] b, final int offset, final int length) throws IOException {
-      read(b, offset, length);
+      // read() here either transfers exactly length bytes or throws, so a
+      // short count means the end of the value was reached prematurely.
+      if (read(b, offset, length) != length) {
+        throw new EOFException();
+      }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Resolves all nine open `java/ignored-error-status-of-call` CodeQL alerts. Each
site threw away the result of a stream `read`/`skip` or of `File.renameTo`, so a
short read, an incomplete skip, or a failed rename went unnoticed.

| File | Call | Fix |
|---|---|---|
| `StreamLoader.java` (139, 141) | `DataInputStream.read(buf, off, len)` for record key/value | switch to `readFully` |
| `Value.java` (4894, 4899) | `read` inside `readFully` overrides | check the count, throw `EOFException` on a short read |
| `IOMeter.java` (455) | `InputStream.skip` in the dump `main` | loop until fully skipped |
| `BackupTask.java` (263) | `File.renameTo` | throw `IOException` when it returns `false` |
| `WDSSO.java` (288, 326) | `ByteArrayInputStream.read` for SPNEGO / Kerberos OID | require a full read before matching the OID |
| `DerValue.java` (91) | `ByteArrayInputStream.read` for DER content | truncate to the bytes actually read |

## Why it is safe

For every **well-formed** input these calls already transferred the full amount:

- `StreamLoader` reads from a `DataInputStream`; `readFully` reads exactly the
  requested bytes or throws `EOFException` — for a complete stream the byte
  count is identical to before, but a short read (buffered / socket source) can
  no longer deliver a half-filled key or value.
- `Value.ValueObjectInputStream.read` already transfers exactly `length` bytes
  or throws `IOException`, so the added `!= length` guard only documents and
  enforces the existing `DataInput.readFully` contract.
- `IOMeter.main` is a diagnostic dumper; the skip loop reaches the same offset,
  just correctly when `skip` returns fewer bytes than requested.
- `BackupTask.rename` only reaches the new `throw` when `renameTo` actually
  fails — previously that failure was reported as success.
- In `WDSSO`/`DerValue` a valid token fills the OID / DER buffers completely, so
  the guard is `true` and the comparison result is unchanged; a **truncated**
  token now fails closed instead of being compared against zero-filled trailing
  bytes.

So the change is behaviour-preserving for all existing (valid) inputs and only
surfaces genuinely truncated or failed I/O.

## Copyright

Adds the missing `Portions Copyrighted 2026 3A Systems, LLC` header line to
`StreamLoader.java`, `BackupTask.java`, `WDSSO.java` and `DerValue.java`
(`Value.java` and `IOMeter.java` already carry it). The `@Checkstyle:ignoreFor`
count in the two ForgeRock CDDL headers is bumped by one to keep covering the
extended header.

## Testing

`mvn -o -pl persistit/core,commons/auth-filters/authn-filter/jaspi-modules/iwa-module -am compile` — BUILD SUCCESS.
