### PR TITLE
Synchronize overrides of synchronized methods (CodeQL java/non-sync-override)

### DIFF
--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/ByteArrayBranchingStream.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/ByteArrayBranchingStream.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.io;
@@ -102,7 +103,7 @@ final class ByteArrayBranchingStream extends BranchingInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         mark = position;
     }
 

--- a/persistit/core/src/main/java/com/persistit/PersistitMap.java
+++ b/persistit/core/src/main/java/com/persistit/PersistitMap.java
@@ -741,7 +741,7 @@ public class PersistitMap<K, V> extends AbstractMap<K, V> implements SortedMap<K
         }
 
         @Override
-        public Throwable getCause() {
+        public synchronized Throwable getCause() {
             return _exception;
         }
     }

--- a/persistit/core/src/main/java/com/persistit/Value.java
+++ b/persistit/core/src/main/java/com/persistit/Value.java
@@ -5056,12 +5056,12 @@ public final class Value {
     }
 
     @Override
-    public void mark(final int readLimit) {
+    public synchronized void mark(final int readLimit) {
       _mark = _value._next;
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
       if (_mark < 0) {
         throw new IOException("No mark");
       } else {


### PR DESCRIPTION
## Summary

Resolves all four open `java/non-sync-override` CodeQL alerts. Each method
overrode a `synchronized` method from `java.io.InputStream` or
`java.lang.Throwable` but dropped the `synchronized` modifier, so a caller that
relies on the base-class locking contract silently loses it on these subtypes.
The fix restores the modifier on each override.

| File | Method | Overrides |
|---|---|---|
| `ByteArrayBranchingStream.java` (105) | `mark` | `InputStream.mark` |
| `Value.java` (5059) | `mark` | `InputStream.mark` |
| `Value.java` (5064) | `reset` | `InputStream.reset` |
| `PersistitMap.java` (744) | `getCause` | `Throwable.getCause` |

## Why it is safe

- **`ByteArrayBranchingStream.mark`** — the class already declares `read`,
  `skip`, `available` and `reset` as `synchronized`, and they all read/write the
  shared `position` / `mark` fields. `mark` was the one method mutating `mark`
  from `position` without the lock, so adding `synchronized` simply makes it
  consistent with its siblings.
- **`Value.OldValueInputStream.mark` / `reset`** — this is the
  `ObjectInputStream` used to decode a `Value`; both methods touch the shared
  `_mark` / `_value._next` cursor. Synchronizing restores the `InputStream`
  contract.
- **`PersistitMap.PersistitMapException.getCause`** — restores the
  `Throwable.getCause` contract for this unchecked wrapper.

Every one of these methods only reads or writes its own instance fields and
calls nothing that takes another lock, so adding `synchronized` cannot introduce
a lock-ordering deadlock. Single-threaded callers see no behavioural change.

## Testing

`mvn -o -pl commons/http-framework/core,persistit/core -am compile` — BUILD SUCCESS.
