### PR TITLE
Reference the supplied format arguments (CodeQL java/unused-format-argument)

### DIFF
--- a/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
@@ -314,7 +314,7 @@ public class OpenAMSessionModule implements AsyncServerAuthModule {
             public Promise<AuthStatus, AuthenticationException> apply(Response response) {
                 try {
                     if (!response.getStatus().isSuccessful()) {
-                        LOG.error("REST validation call returned non HTTP 200 response",
+                        LOG.error("REST validation call returned non HTTP 200 response: {}",
                                 response.getEntity().getString());
                         return newResultPromise(SEND_FAILURE);
                     }
@@ -365,7 +365,7 @@ public class OpenAMSessionModule implements AsyncServerAuthModule {
             public AuthStatus apply(Response response) throws AuthenticationException {
                 if (!response.getStatus().isSuccessful()) {
                     try {
-                        LOG.error("REST validation call returned non HTTP 200 response",
+                        LOG.error("REST validation call returned non HTTP 200 response: {}",
                                 response.getEntity().getString());
                         return SEND_FAILURE;
                     } catch (IOException e) {

--- a/commons/selfservice/core/src/main/java/org/forgerock/selfservice/core/crypto/FieldStorageSchemeImpl.java
+++ b/commons/selfservice/core/src/main/java/org/forgerock/selfservice/core/crypto/FieldStorageSchemeImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.selfservice.core.crypto;
 
@@ -121,14 +122,14 @@ class FieldStorageSchemeImpl implements FieldStorageScheme {
 
             saltLength = decodedBytes.length - digestSize;
             if (saltLength <= 0) {
-                logger.error("Invalid decoded stored field", storedField);
+                logger.error("Invalid decoded stored field: {}", storedField);
                 return false;
             }
             saltBytes = new byte[saltLength];
             System.arraycopy(decodedBytes, 0, digestBytes, 0, digestSize);
             System.arraycopy(decodedBytes, digestSize, saltBytes, 0, saltLength);
         } catch (Exception e) {
-            logger.error("Cannot decode stored field", storedField, e);
+            logger.error("Cannot decode stored field: {}", storedField, e);
             return false;
         }
 
@@ -145,7 +146,7 @@ class FieldStorageSchemeImpl implements FieldStorageScheme {
             try {
                 userDigestBytes = messageDigest.digest(plainPlusSalt);
             } catch (Exception e) {
-                logger.error("Cannot encode field", storedField, e);
+                logger.error("Cannot encode field: {}", storedField, e);
                 return false;
             } finally {
                 Arrays.fill(plainPlusSalt, (byte) 0);

--- a/persistit/core/src/main/java/com/persistit/util/Util.java
+++ b/persistit/core/src/main/java/com/persistit/util/Util.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit.util;
@@ -581,7 +582,7 @@ public class Util {
             throw new IllegalArgumentException(String.format("Value must be greater than or equal to %,d: %,d", min,
                     value));
         } else {
-            throw new IllegalArgumentException(String.format("Value must be between %d and %d, inclusive: ", min, max,
+            throw new IllegalArgumentException(String.format("Value must be between %d and %d, inclusive: %d", min, max,
                     value));
         }
     }
@@ -598,7 +599,7 @@ public class Util {
             throw new IllegalArgumentException(String.format("Value must be greater than or equal to %,d: %,d", min,
                     value));
         } else {
-            throw new IllegalArgumentException(String.format("Value must be between %d and %d, inclusive: ", min, max,
+            throw new IllegalArgumentException(String.format("Value must be between %d and %d, inclusive: %d", min, max,
                     value));
         }
     }
@@ -615,7 +616,7 @@ public class Util {
             throw new IllegalArgumentException(String.format("Value must be greater than or equal to %,f: %,f", min,
                     value));
         } else {
-            throw new IllegalArgumentException(String.format("Value must be between %f and %f, inclusive: ", min, max,
+            throw new IllegalArgumentException(String.format("Value must be between %f and %f, inclusive: %f", min, max,
                     value));
         }
     }

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/SLF4JErrorReporter.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/SLF4JErrorReporter.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -49,14 +51,14 @@ public class SLF4JErrorReporter implements ErrorReporter {
 
     public void warning(String message, String sourceName, int line, String lineSource,
             int lineOffset) {
-        logger.warn("", new Object[] { message, sourceName, line, lineSource, lineOffset });
+        logger.warn("{} ({}#{}): {} [offset {}]", new Object[] { message, sourceName, line, lineSource, lineOffset });
         if (chainedReporter != null) {
             chainedReporter.warning(message, sourceName, line, lineSource, lineOffset);
         }
     }
 
     public void error(String message, String sourceName, int line, String lineSource, int lineOffset) {
-        logger.error("", new Object[] { message, sourceName, line, lineSource, lineOffset });
+        logger.error("{} ({}#{}): {} [offset {}]", new Object[] { message, sourceName, line, lineSource, lineOffset });
         if (chainedReporter != null) {
             chainedReporter.error(message, sourceName, line, lineSource, lineOffset);
         } else {


### PR DESCRIPTION
## Summary

Resolves all ten open `java/unused-format-argument` CodeQL alerts. Every flagged
site supplied arguments that the format string never referenced, so those values
were silently dropped from the log line / exception message. The fix adds the
missing placeholders so the arguments are actually rendered.

| File | Line(s) | Before | Fix |
|---|---|---|---|
| `SLF4JErrorReporter.java` | 52, 59 | `logger.warn("", {5 args})` / `logger.error("", {5 args})` | format with five `{}` placeholders |
| `Util.java` | 584, 601, 618 | `"Value must be between %d and %d, inclusive: "` + `value` | append the matching `%d` / `%f` specifier |
| `FieldStorageSchemeImpl.java` | 124, 131, 148 | `logger.error("…", storedField[, e])` with no `{}` | add `: {}` for the stored field |
| `OpenAMSessionModule.java` | 317, 368 | `LOG.error("…non HTTP 200 response", body)` | add `: {}` for the response body |

## Why these are real

- **`SLF4JErrorReporter`** — the format string was the empty string, so the
  JavaScript error's message, source, line, line-source and offset were never
  logged. Now all five are rendered.
- **`Util.rangeCheck`** — the "between" message ended right after `inclusive: `
  and dropped the actual out-of-range value, unlike the sibling "less than" /
  "greater than" messages which do print it. The value is now shown.
- **`FieldStorageSchemeImpl`** — the three `logger.error` calls had no `{}`, so
  the stored field never appeared. On the two-argument calls the trailing
  `Throwable` is still logged as the exception (SLF4J trailing-throwable
  handling); only the stored-field placeholder was missing.
- **`OpenAMSessionModule`** — the non-2xx REST validation response body was
  passed but not referenced, so the diagnostic body was lost.

No behavioural change beyond the previously discarded values now reaching the
message.

## Testing

`mvn -o -pl script/javascript,persistit/core,commons/selfservice/core,commons/auth-filters/authn-filter/jaspi-modules/openam-session-module compile` — each module builds (BUILD SUCCESS).
