### PR TITLE
Remove useless null checks (CodeQL java/useless-null-check)

### DIFF
--- a/commons/geo/src/main/java/ru/org/openam/geo/Info.java
+++ b/commons/geo/src/main/java/ru/org/openam/geo/Info.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2020-2024 3A Systems LLC.
+ * Copyright 2020-2026 3A Systems LLC.
  */
 
 package ru.org.openam.geo;
@@ -48,9 +48,9 @@ public class Info {
 	@Override
 	public String toString() {
 		if (ip!=null&&ip.isSiteLocalAddress())
-			return MessageFormat.format("{0} ({1})",(ip!=null)?ip.getHostAddress():ipString,"LAN");
+			return MessageFormat.format("{0} ({1})",ip.getHostAddress(),"LAN");
 		else if (ip!=null&&ip.isLoopbackAddress())
-			return MessageFormat.format("{0} ({1})",(ip!=null)?ip.getHostAddress():ipString,"LOCALHOST");
+			return MessageFormat.format("{0} ({1})",ip.getHostAddress(),"LOCALHOST");
 		else if (l!=null)
 			return MessageFormat.format("{0} ({1}:{2}/{3})",
 					(ip!=null)?ip.getHostAddress():ipString,

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/protocol/Cookie.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/protocol/Cookie.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.protocol;
@@ -285,7 +286,7 @@ public class Cookie {
         result = prime * result + (maxAge == null ? 0 : maxAge.hashCode());
         result = prime * result + (name == null ? 0 : name.hashCode());
         result = prime * result + (path == null ? 0 : path.hashCode());
-        result = prime * result + (port == null ? 0 : port.hashCode());
+        result = prime * result + port.hashCode();
         result = prime * result + (secure == null ? 0 : secure.hashCode());
         result = prime * result + (sameSite == null ? 0 : sameSite.hashCode());
         result = prime * result + (value == null ? 0 : value.hashCode());
@@ -488,9 +489,7 @@ public class Cookie {
         if (path != null) {
             builder.append("path=").append(path).append(" ");
         }
-        if (port != null) {
-            builder.append("port=").append(port).append(" ");
-        }
+        builder.append("port=").append(port).append(" ");
         if (secure != null) {
             builder.append("secure=").append(secure).append(" ");
         }

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
@@ -334,14 +334,13 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
                             		   );
                 }
             } else {
-                input =
-                        new BufferedReader(new InputStreamReader(Main.class
-                                .getResourceAsStream("/launcher.json")));
-                if (null == input) {
+                final InputStream configStream = Main.class.getResourceAsStream("/launcher.json");
+                if (null == configStream) {
                     throw new IllegalArgumentException(
                             "Boot OSGi configuration file does not exists on CLASSPATH: "
                                     + Main.class.getResource("/").toString() + "/launcher.json");
                 }
+                input = new BufferedReader(new InputStreamReader(configStream));
             }
             launcherConfiguration = new JsonValue((new JSONParser()).parse(input));
             launcherConfiguration.getTransformers().add(transformer);

--- a/persistit/core/src/main/java/com/persistit/Persistit.java
+++ b/persistit/core/src/main/java/com/persistit/Persistit.java
@@ -1736,12 +1736,10 @@ public class Persistit {
    */
   public void crash() {
     final JournalManager journalManager = _journalManager;
-    if (journalManager != null) {
-      try {
-        journalManager.crash();
-      } catch (final IOException e) {
-        _logBase.exception.log(e);
-      }
+    try {
+      journalManager.crash();
+    } catch (final IOException e) {
+      _logBase.exception.log(e);
     }
     //
     // Even on simulating a crash we need to try to close
@@ -1757,10 +1755,8 @@ public class Persistit {
       }
     }
     final Map<Integer, BufferPool> buffers = _bufferPoolTable;
-    if (buffers != null) {
-      for (final BufferPool pool : buffers.values()) {
-        pool.crash();
-      }
+    for (final BufferPool pool : buffers.values()) {
+      pool.crash();
     }
     _transactionIndex.crash();
     _cleanupManager.crash();


### PR DESCRIPTION
## Summary

Resolves all seven open `java/useless-null-check` CodeQL alerts. Each site tested
a value that provably cannot be null at that point, so the guarded branch (or the
null arm of a ternary) was dead.

| File | Line(s) | Value | Why it can't be null |
|---|---|---|---|
| `Persistit.java` | 1739, 1760 | `_journalManager`, `_bufferPoolTable` | `final` fields initialised inline to `new …()` |
| `Cookie.java` | 288, 491 | `port` | `final List<Integer> = new ArrayList<>()`, never reassigned |
| `Info.java` | 51, 53 | `ip` | branch already guarded by `ip != null` |
| `OSGiFrameworkService.java` | 340 | `input` | freshly assigned `new BufferedReader(...)` |

## Notes

- **`Persistit.crash`** — the two `!= null` guards are always true; the bodies now
  run unconditionally.
- **`Cookie`** — `hashCode()` uses `port.hashCode()` directly and `toString()`
  appends `port` unconditionally (it was already appended on every call, since the
  guard could never be false).
- **`Info.toString`** — the `ip != null ? ip.getHostAddress() : ipString`
  ternaries are inside `if (ip != null && …)` branches, so they always take the
  non-null arm. The other, unguarded ternaries further down are left untouched.
- **`OSGiFrameworkService`** — this one hid a real bug. The check was on the
  `BufferedReader`, which a constructor never returns as null, so the intended
  failure mode (a missing `/launcher.json` on the classpath) was never caught:
  `getResourceAsStream` returns `null` and `new InputStreamReader(null)` then
  throws `NullPointerException`. The null check now guards the resource stream
  before it is wrapped, so the intended `IllegalArgumentException` is thrown.

Behaviour is unchanged for every existing input; the OSGi case additionally
reports the missing-resource error cleanly instead of as an NPE.

## Testing

`mvn -o -pl commons/geo,persistit/core,commons/http-framework/core,commons/launcher/launcher compile` — each module builds (BUILD SUCCESS).
