### PR TITLE
Declare never-null local variables as primitives (CodeQL java/non-null-boxed-variable)

### DIFF
--- a/commons/audit/core/src/main/java/org/forgerock/audit/util/DateUtil.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/util/DateUtil.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2011-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.util;
 
@@ -204,9 +205,9 @@ public final class DateUtil {
     public static int getDateDifferenceInDays(final Date start, final Date end, final Boolean includeDay) {
         Integer result = null;
         if (start != null && end != null) {
-            final Long l = 86400000L;
-            final Long r = (end.getTime() - start.getTime()) / l;
-            result = r.intValue();
+            final long l = 86400000L;
+            final long r = (end.getTime() - start.getTime()) / l;
+            result = (int) r;
             if (includeDay) {
                 result++;
             }

--- a/commons/audit/core/src/main/java/org/forgerock/audit/util/JsonValueUtils.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/util/JsonValueUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.audit.util;
@@ -479,9 +480,9 @@ public final class JsonValueUtils {
                     final String s2 = (String) v2;
                     return s1.compareToIgnoreCase(s2);
                 } else if (v1 instanceof Number && v2 instanceof Number) {
-                    final Double n1 = ((Number) v1).doubleValue();
-                    final Double n2 = ((Number) v2).doubleValue();
-                    return n1.compareTo(n2);
+                    final double n1 = ((Number) v1).doubleValue();
+                    final double n2 = ((Number) v2).doubleValue();
+                    return Double.compare(n1, n2);
                 } else if (v1 instanceof Boolean && v2 instanceof Boolean) {
                     final Boolean b1 = (Boolean) v1;
                     final Boolean b2 = (Boolean) v2;

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -360,9 +361,9 @@ public final class MemoryBackend implements CollectionResourceProvider {
             final String s2 = (String) v2;
             return s1.compareToIgnoreCase(s2);
         } else if (v1 instanceof Number && v2 instanceof Number) {
-            final Double n1 = ((Number) v1).doubleValue();
-            final Double n2 = ((Number) v2).doubleValue();
-            return n1.compareTo(n2);
+            final double n1 = ((Number) v1).doubleValue();
+            final double n2 = ((Number) v2).doubleValue();
+            return Double.compare(n1, n2);
         } else if (v1 instanceof Boolean && v2 instanceof Boolean) {
             final Boolean b1 = (Boolean) v1;
             final Boolean b2 = (Boolean) v2;

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
@@ -81,7 +81,7 @@ public class InstallExternalDependencyMojo extends
             super.md5Digester = this.md5Digester;
             super.sha1Digester = this.sha1Digester;
 
-            Boolean cachedCreateChecksums = this.createChecksum;
+            boolean cachedCreateChecksums = this.createChecksum;
 
             getLog()
                 .info(
@@ -101,7 +101,7 @@ public class InstallExternalDependencyMojo extends
 
                 // determine if the artifact is already installed in the local
                 // Maven repository
-                Boolean artifactAlreadyInstalled = getLocalRepoFile(artifact)
+                boolean artifactAlreadyInstalled = getLocalRepoFile(artifact)
                     .exists();
 
                 // only proceed with this artifact if it is not already

--- a/persistit/core/src/main/java/com/persistit/util/ThreadSequencer.java
+++ b/persistit/core/src/main/java/com/persistit/util/ThreadSequencer.java
@@ -202,7 +202,7 @@ public class ThreadSequencer implements SequencerConstants {
     public static String describeHistory(final int[] history) {
         final StringBuilder sb = new StringBuilder();
         if (history != null) {
-            for (final Integer location : history) {
+            for (final int location : history) {
                 if (sb.length() > 0) {
                     sb.append(',');
                 }


### PR DESCRIPTION
## Summary

Resolves all seven open `java/non-null-boxed-variable` CodeQL alerts. Each local
variable was declared with a boxed wrapper type but only ever assigned a
primitive value and never `null`, so it paid for boxing plus an implicit unbox on
every use. Each is now declared with the matching primitive type.

| File | Line(s) | Variable | Was → Now |
|---|---|---|---|
| `DateUtil.java` | 207, 208 | `l`, `r` | `Long` → `long` |
| `MemoryBackend.java` | 363 | `n1`, `n2` | `Double` → `double` |
| `JsonValueUtils.java` | 482 | `n1`, `n2` | `Double` → `double` |
| `ThreadSequencer.java` | 205 | `location` | `Integer` → `int` |
| `InstallExternalDependencyMojo.java` | 84, 104 | `cachedCreateChecksums`, `artifactAlreadyInstalled` | `Boolean` → `boolean` |

## Why this is behaviour-preserving

- **`DateUtil`** — `l`/`r` are computed from `long` arithmetic; `r.intValue()`
  becomes `(int) r` (identical narrowing). The nullable `result` stays `Integer`.
- **`MemoryBackend` / `JsonValueUtils`** — `n1.compareTo(n2)` on `Double` is
  replaced by `Double.compare(n1, n2)`, which is exactly the primitive comparison
  `Double.compareTo` delegates to (same `NaN` / `-0.0` ordering).
- **`ThreadSequencer`** — the loop iterates an `int[]`; `appendHistoryElement`
  already accepts an `int`, so nothing downstream changes.
- **`InstallExternalDependencyMojo`** — `cachedCreateChecksums` comes from the
  `boolean createChecksum` field and is written back to it; `artifactAlreadyInstalled`
  comes from `File.exists()` and is only used in a boolean expression.

Every value was already unboxed at its point of use, so there is no behavioural
change.

## Testing

`mvn -o -pl persistit/core,commons/audit/core,commons/rest/json-resource,maven-external-dependency-plugin/maven-external-dependency-plugin compile` — each module builds (BUILD SUCCESS).
