### PR TITLE
Stop shadowing Task._stop and Task._lastException (CodeQL java/field-masks-super-field)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/StreamLoader.java
+++ b/persistit/core/src/main/java/com/persistit/StreamLoader.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -50,8 +51,6 @@ public class StreamLoader extends Task {
     protected Tree _lastTree;
     protected int _dataRecordCount = 0;
     protected int _otherRecordCount = 0;
-    protected boolean _stop;
-    protected Exception _lastException;
 
     protected TreeSelector _treeSelector;
     protected boolean _createMissingVolumes;

--- a/persistit/core/src/main/java/com/persistit/StreamSaver.java
+++ b/persistit/core/src/main/java/com/persistit/StreamSaver.java
@@ -115,8 +115,6 @@ public class StreamSaver extends Task {
     protected long _dataRecordCount = 0;
     protected long _otherRecordCount = 0;
     protected int _cycleCount = DEFAULT_CYCLE_COUNT;
-    protected boolean _stop;
-    protected Exception _lastException;
     protected int _recordCount;
     protected TreeSelector _treeSelector;
 
@@ -244,7 +242,7 @@ public class StreamSaver extends Task {
      */
     public void close() throws IOException {
         writeTimestamp();
-        if (!_stop && _lastException == null)
+        if (!_stop.get() && _lastException == null)
             _dos.writeChar(RECORD_TYPE_COMPLETION);
         _lastTree = null;
         _lastVolume = null;
@@ -456,7 +454,7 @@ public class StreamSaver extends Task {
         }
         final Key key = exchange.getKey();
         key.clear().append(Key.BEFORE);
-        while (exchange.traverse(Key.GT, filter, Integer.MAX_VALUE) & !_stop) {
+        while (exchange.traverse(Key.GT, filter, Integer.MAX_VALUE) & !_stop.get()) {
             writeData(exchange);
         }
         writeRecordCount(_dataRecordCount, _otherRecordCount);
@@ -497,7 +495,7 @@ public class StreamSaver extends Task {
     public void saveTrees(final Volume volume, final String[] selectedTreeNames) throws PersistitException, IOException {
         final String[] treeNames = volume.getTreeNames();
         writeComment("Volume " + volume.getPath());
-        for (int index = 0; index < treeNames.length & !_stop; index++) {
+        for (int index = 0; index < treeNames.length & !_stop.get(); index++) {
             boolean selected = true;
             if (selectedTreeNames != null) {
                 for (int index2 = 0; selected && index2 < selectedTreeNames.length; index2++) {
@@ -567,7 +565,7 @@ public class StreamSaver extends Task {
     public void saveAll() throws PersistitException, IOException {
 
         for (final Volume volume : _persistit.getVolumes()) {
-            if (_stop) {
+            if (_stop.get()) {
                 break;
             }
             saveTrees(volume, null);

--- a/persistit/core/src/main/java/com/persistit/StreamSaver.java
+++ b/persistit/core/src/main/java/com/persistit/StreamSaver.java
@@ -454,7 +454,7 @@ public class StreamSaver extends Task {
         }
         final Key key = exchange.getKey();
         key.clear().append(Key.BEFORE);
-        while (exchange.traverse(Key.GT, filter, Integer.MAX_VALUE) & !_stop.get()) {
+        while (exchange.traverse(Key.GT, filter, Integer.MAX_VALUE) && !_stop.get()) {
             writeData(exchange);
         }
         writeRecordCount(_dataRecordCount, _otherRecordCount);
@@ -495,7 +495,7 @@ public class StreamSaver extends Task {
     public void saveTrees(final Volume volume, final String[] selectedTreeNames) throws PersistitException, IOException {
         final String[] treeNames = volume.getTreeNames();
         writeComment("Volume " + volume.getPath());
-        for (int index = 0; index < treeNames.length & !_stop.get(); index++) {
+        for (int index = 0; index < treeNames.length && !_stop.get(); index++) {
             boolean selected = true;
             if (selectedTreeNames != null) {
                 for (int index2 = 0; selected && index2 < selectedTreeNames.length; index2++) {


### PR DESCRIPTION
## Summary

Addresses the `java/field-masks-super-field` alerts in `StreamLoader` and
`StreamSaver`. Both classes extend `Task` and redeclared `_stop` and
`_lastException`, which `Task` already declares, so the subclasses shadowed the
base fields instead of sharing them — a real defect, not just style.

| File | Field | Superclass field | Effect of the shadow |
|---|---|---|---|
| `StreamSaver.java` | `_stop` (`boolean`) | `Task._stop` (`AtomicBoolean`) | save loops never saw a cancellation request |
| `StreamSaver.java` | `_lastException` | `Task._lastException` | recorded failure never reached the task status |
| `StreamLoader.java` | `_stop`, `_lastException` | `Task._stop`, `Task._lastException` | dead shadow fields, never read or written |

## Details

- **`StreamSaver._stop`** — `Task._stop` is an `AtomicBoolean` that `Task.stop()`
  flips to request cancellation. `StreamSaver`'s own `boolean _stop` was never
  assigned, so `saveAll`, `saveTrees` and the traversal loop kept running even
  after a stop was requested. The shadow is removed and the loops now test the
  inherited `_stop.get()`.
- **`StreamSaver._lastException`** — `Task` reports `_lastException` in the task
  status; `StreamSaver` wrote its own copy, so the status stayed `none`. Removing
  the shadow lets the recorded exception surface.
- **`StreamLoader`** — its `_stop` / `_lastException` were never read or written,
  so they are just removed.

For a normal (non-cancelled) run `_stop` is `false` throughout, so the loops
behave exactly as before; the change only lets a cancellation take effect and the
recorded exception appear in the task status.

## Not changed here

The two remaining alerts on `InstallExternalDependencyMojo.installer` and
`AbstractExternalDependencyMojo.artifactFactory` are **intentional**: these are
Maven 2 `@component` fields re-declared in the plugin's own source so the
QDox-based plugin-descriptor generator emits the Plexus injection requirement
(the base classes live in compiled Maven artifacts whose `@component` tags the
generator cannot see). Removing them would drop the injection and NPE at runtime,
so they are left as-is.

## Testing

`mvn -o -pl persistit/core compile` — BUILD SUCCESS.
