### PR TITLE
Launch AdminUI helper threads outside the constructor (CodeQL java/thread-start-in-constructor)

### DIFF
--- a/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit.ui;
@@ -202,11 +203,20 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
     public AdminUI(final String rmiHost) {
         this();
         _rmiHost = rmiHost;
-        if (rmiHost != null)
-            connect(rmiHost);
     }
 
     public AdminUI() {
+    }
+
+    /**
+     * Builds and displays the UI. Invoke this once, after construction, from a
+     * thread other than the AWT event-dispatch thread: it launches the
+     * frame-building helper thread and waits for it to finish. The thread starts
+     * are kept out of the constructor so that {@code this} does not escape to the
+     * helper threads before construction has completed (CodeQL
+     * java/thread-start-in-constructor).
+     */
+    public void launch() {
         //
         // This is a workaround for JVM bug 4030718 in JDK1.3.
         // (See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4030718).
@@ -855,7 +865,12 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
     }
 
     public static void main(final String[] args) {
-        new AdminUI(args.length > 0 ? args[0] : null);
+        final String rmiHost = args.length > 0 ? args[0] : null;
+        final AdminUI adminUI = new AdminUI(rmiHost);
+        adminUI.launch();
+        if (rmiHost != null) {
+            adminUI.connect(rmiHost);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Resolves both `java/thread-start-in-constructor` alerts in `AdminUI` (lines 234
and 247). The `AdminUI()` constructor started two threads:

- a frame-building thread (creates the `JFrame`/splash, then `setupFrame()`),
  joined before the constructor returned; and
- a host-name lookup thread (`InetAddress.getLocalHost()`), fire-and-forget.

Both are anonymous `Thread` subclasses that capture `this`, so they could observe
`AdminUI` before its construction finished — the exact pattern the rule warns
about (most dangerous if the class is subclassed and a helper thread calls an
overridden method against uninitialised subclass state).

## Change

The thread block is moved verbatim from the constructor into a new
`public void launch()` method, and `main()` calls it right after construction:

```java
final AdminUI adminUI = new AdminUI(rmiHost);
adminUI.launch();
if (rmiHost != null) {
    adminUI.connect(rmiHost);
}
```

`AdminUI` is only ever instantiated by its own `main()` (verified across the
repo — the other UI classes just hold a reference handed to their `setup(ui)`
methods), so moving the launch out of the constructor affects no other caller.

## Behaviour

The `main()` sequence is unchanged: construct (records the RMI host) → `launch()`
(builds the frame, waits for it, kicks off the host-name lookup) → `connect()`.
The frame is still fully built before `connect()` runs, so the RMI connection and
window title behave exactly as before. The `connect()` call previously performed
inside the `AdminUI(String)` constructor now runs from `main()` after `launch()`;
`refresh()` already guards `_tabbedPane != null`, so the remaining convenience
constructors stay safe.

## Testing

`mvn -o -pl persistit/ui compile` — BUILD SUCCESS.
