### PR TITLE
Qualify the LinkedHashMap size() call in removeEldestEntry (CodeQL java/subtle-inherited-call)

### DIFF
--- a/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/AccessTokenValidationCache.java
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/AccessTokenValidationCache.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.authz.modules.oauth2;
@@ -47,7 +48,11 @@ class AccessTokenValidationCache {
 
             @Override
             protected boolean removeEldestEntry(Map.Entry<String, AccessTokenValidationResponse> eldestEntry) {
-                return size() > maxSize;
+                // size() refers to this LinkedHashMap's own size, not the enclosing
+                // AccessTokenValidationCache.size() (which would re-acquire the read lock while a
+                // put() already holds the write lock). Qualify with super to make that explicit
+                // (CodeQL java/subtle-inherited-call).
+                return super.size() > maxSize;
             }
         };
     }


### PR DESCRIPTION
## Summary

Resolves the `java/subtle-inherited-call` alert in `AccessTokenValidationCache`.

The cache is backed by an anonymous `LinkedHashMap` subclass whose
`removeEldestEntry` override calls an unqualified `size()`:

```java
protected boolean removeEldestEntry(Map.Entry<...> eldestEntry) {
    return size() > maxSize;
}
```

`size()` binds to `LinkedHashMap.size()` (the map's own size — the correct,
standard LRU idiom). But the enclosing `AccessTokenValidationCache` also declares
a `size()` method, so a reader could mistake the call for the enclosing one — and
that enclosing `size()` re-acquires the read lock, which would be wrong here since
`removeEldestEntry` runs inside `put()` while the write lock is already held.

## Fix

Qualify the call as `super.size()`, making it explicit that the map's own
inherited size is intended. This is behaviour-preserving — the unqualified call
already resolved to `LinkedHashMap.size()`.

## Testing

`mvn -o -pl commons/auth-filters/authz-filter/modules/oauth2-module compile` — BUILD SUCCESS.
