### PR TITLE
Use notifyAll in IOTaskRunnable.kick (CodeQL java/notify-instead-of-notify-all)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/IOTaskRunnable.java
+++ b/persistit/core/src/main/java/com/persistit/IOTaskRunnable.java
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -64,7 +65,7 @@ abstract class IOTaskRunnable implements Runnable {
     synchronized void kick() {
         if (!_notified) {
             _notified = true;
-            notify();
+            notifyAll();
         }
     }
 


### PR DESCRIPTION
## Summary

Resolves the `java/notify-instead-of-notify-all` alert in `IOTaskRunnable`.

`kick()` woke a blocked worker with `notify()`:

```java
synchronized void kick() {
    if (!_notified) {
        _notified = true;
        notify();
    }
}
```

Each `IOTaskRunnable` has exactly one background thread (created in `start()`),
and that thread is the only one that ever calls `wait()` on the monitor (in
`run()`), so `notify()` and `notifyAll()` are functionally equivalent today.
However, `notify()` is fragile — if any other thread ever waited on the same
monitor, it could wake the wrong one and leave the worker blocked.

## Fix

Use `notifyAll()`. With a single waiter it wakes exactly the same thread (no
thundering herd), and the wait loop already re-checks its guards
(`shouldStop()` / `_notified` / recomputed wait time), so additional wake-ups are
handled correctly.

## Testing

`mvn -o -pl persistit/core compile` — BUILD SUCCESS.
