### PR TITLE
Handle the STRICT host name verifier explicitly (CodeQL java/missing-case-in-switch)

### DIFF
--- a/commons/http-framework/client-apache-async/src/main/java/org/forgerock/http/apache/async/AsyncHttpClientProvider.java
+++ b/commons/http-framework/client-apache-async/src/main/java/org/forgerock/http/apache/async/AsyncHttpClientProvider.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.apache.async;
@@ -128,10 +129,14 @@ public class AsyncHttpClientProvider implements HttpClientProvider {
             throw new HttpApplicationException("Can't create SSL Context", e);
         }
 
-        HostnameVerifier verifier = new DefaultHostnameVerifier();
+        final HostnameVerifier verifier;
         switch (options.get(OPTION_HOSTNAME_VERIFIER)) {
         case ALLOW_ALL:
             verifier = NoopHostnameVerifier.INSTANCE;
+            break;
+        default:
+            // STRICT (and any future policy) uses strict host name verification.
+            verifier = new DefaultHostnameVerifier();
             break;
         }
 


### PR DESCRIPTION
## Summary

Resolves the `java/missing-case-in-switch` alert in `AsyncHttpClientProvider`
(the switch had no case for `HostnameVerifier.STRICT`).

The switch pre-initialised the verifier and only overrode it for `ALLOW_ALL`:

```java
HostnameVerifier verifier = new DefaultHostnameVerifier();
switch (options.get(OPTION_HOSTNAME_VERIFIER)) {
case ALLOW_ALL:
    verifier = NoopHostnameVerifier.INSTANCE;
    break;
}
```

`STRICT` therefore fell through and kept the default `DefaultHostnameVerifier`
(the correct behaviour), but the switch covered only one of the two enum values.

## Fix

Add a `default` branch that assigns `DefaultHostnameVerifier`, matching the shape
already used by the sibling `SyncHttpClientProvider`:

```java
final HostnameVerifier verifier;
switch (options.get(OPTION_HOSTNAME_VERIFIER)) {
case ALLOW_ALL:
    verifier = NoopHostnameVerifier.INSTANCE;
    break;
default:
    verifier = new DefaultHostnameVerifier();
    break;
}
```

Behaviour is unchanged (`STRICT` still maps to `DefaultHostnameVerifier`); the
switch now covers every value and the two providers are consistent.

## Testing

`mvn -o -pl commons/http-framework/client-apache-async compile` — BUILD SUCCESS.
