### PR TITLE
Use short-circuit && in Exchange.removeKeyRangeInternal (CodeQL java/non-short-circuit-evaluation)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -3661,7 +3661,7 @@ public class Exchange implements ReadOnlyExchange {
 
           LevelCache lc = _levelCache[0];
           if (removeOnlyAntiValue
-            & !isKeyRangeAntiValue(lc._leftBuffer, lc._leftFoundAt, lc._rightBuffer, lc._rightFoundAt)) {
+            && !isKeyRangeAntiValue(lc._leftBuffer, lc._leftFoundAt, lc._rightBuffer, lc._rightFoundAt)) {
             result = false;
             break;
           }


### PR DESCRIPTION
## Summary

Resolves the `java/non-short-circuit-evaluation` alert in `Exchange`.

The anti-value guard used the non-short-circuit `&` operator:

```java
if (removeOnlyAntiValue
    & !isKeyRangeAntiValue(lc._leftBuffer, lc._leftFoundAt, lc._rightBuffer, lc._rightFoundAt)) {
```

so `isKeyRangeAntiValue(...)` was evaluated even when `removeOnlyAntiValue` was
already `false`.

## Fix

Switch to `&&`. `isKeyRangeAntiValue` only reads buffer state (key-block
offsets, right sibling, primordial-anti-value flag) and has no side effects, so
the change is behaviour-preserving — it merely skips the redundant call when
`removeOnlyAntiValue` is `false`.

## Testing

`mvn -o -pl persistit/core compile` — BUILD SUCCESS.
