### PR TITLE
Add missing @Override annotations (CodeQL java/missing-override-annotation)

### DIFF
--- a/bloomfilter/core/src/main/java/org/forgerock/bloomfilter/BloomFilters.java
+++ b/bloomfilter/core/src/main/java/org/forgerock/bloomfilter/BloomFilters.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.bloomfilter;
@@ -297,6 +298,7 @@ public final class BloomFilters {
         }
 
         @VisibleForTesting
+        @Override
         RollingBloomFilterBuilder<T> withClock(final TimeService clock) {
             Reject.ifNull(clock);
             this.clock = clock;

--- a/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
+++ b/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2008 Sun Microsystems, Inc.
  *      Portions copyright 2011-2012 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.testng;
 
@@ -302,6 +303,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         initializeProgressVars();
     }
 
+    @Override
     public void generateReport(final List<XmlSuite> xmlSuites, final List<ISuite> suites,
             final String outputDirectory) {
         final File reportFile = new File(outputDirectory, REPORT_FILE_NAME);
@@ -310,6 +312,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         writeAntTestsFailedMarker(outputDirectory);
     }
 
+    @Override
     public void onConfigurationFailure(final ITestResult tr) {
         super.onConfigurationFailure(tr);
 
@@ -331,6 +334,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         _bufferedTestFailures.append(failureInfo);
     }
 
+    @Override
     public void onStart(final ITestContext testContext) {
         super.onStart(testContext);
 
@@ -338,11 +342,13 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         new File(testContext.getOutputDirectory(), REPORT_FILE_NAME).delete();
     }
 
+    @Override
     public void onTestFailedButWithinSuccessPercentage(final ITestResult tr) {
         super.onTestFailedButWithinSuccessPercentage(tr);
         onTestFinished(tr);
     }
 
+    @Override
     public void onTestFailure(final ITestResult tr) {
         super.onTestFailure(tr);
 
@@ -378,11 +384,13 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         onTestFinished(tr);
     }
 
+    @Override
     public void onTestSkipped(final ITestResult tr) {
         super.onTestSkipped(tr);
         onTestFinished(tr);
     }
 
+    @Override
     public void onTestStart(final ITestResult tr) {
         super.onTestStart(tr);
         enforceTestClassTypeAndAnnotations(tr);
@@ -390,6 +398,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         enforceMethodHasAnnotation(tr);
     }
 
+    @Override
     public void onTestSuccess(final ITestResult tr) {
         super.onTestSuccess(tr);
         onTestFinished(tr);
@@ -584,6 +593,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
         final List<TestClassResults> allClasses = new ArrayList<TestClassResults>(
                 _classResults.values());
         Collections.sort(allClasses, new Comparator<TestClassResults>() {
+            @Override
             public int compare(final TestClassResults o1, final TestClassResults o2) {
                 if (o1._totalDurationMs > o2._totalDurationMs) {
                     return -1;
@@ -607,6 +617,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
     private List<TestMethodResults> getMethodsDescendingSortedByDuration() {
         final List<TestMethodResults> allMethods = getAllMethodResults();
         Collections.sort(allMethods, new Comparator<TestMethodResults>() {
+            @Override
             public int compare(final TestMethodResults o1, final TestMethodResults o2) {
                 if (o1._totalDurationMs > o2._totalDurationMs) {
                     return -1;

--- a/cassandra-embedded/src/main/java/org/openidentityplatform/commons/cassandra/EmbeddedServer.java
+++ b/cassandra-embedded/src/main/java/org/openidentityplatform/commons/cassandra/EmbeddedServer.java
@@ -47,6 +47,7 @@ public class EmbeddedServer implements Runnable, AutoCloseable {
 	final private ExecutorService executor = Executors.newSingleThreadExecutor();
 	private CassandraDaemon cassandraDaemon;
 	    
+	@Override
 	public void run() {
 		try {
 			//check for external cassandra settings
@@ -139,6 +140,7 @@ public class EmbeddedServer implements Runnable, AutoCloseable {
 		}
 	}
 
+	@Override
 	public void close() {
 		if (cassandraDaemon!=null) {
 			cassandraDaemon.stop();

--- a/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/CsvWriter.java
+++ b/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/CsvWriter.java
@@ -48,5 +48,6 @@ interface CsvWriter extends AutoCloseable {
      */
     void flush() throws IOException;
 
+    @Override
     void close() throws IOException;
 }

--- a/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/StandardCsvWriter.java
+++ b/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/StandardCsvWriter.java
@@ -135,6 +135,7 @@ class StandardCsvWriter implements CsvWriter {
      * Flush the data into the CSV file.
      * @throws IOException if an I/O error occurs while flushing.
      */
+    @Override
     public void flush() throws IOException {
         csvWriter.flush();
     }

--- a/commons/audit/handler-jdbc/src/main/java/org/forgerock/audit/handlers/jdbc/BufferedJdbcAuditEventExecutor.java
+++ b/commons/audit/handler-jdbc/src/main/java/org/forgerock/audit/handlers/jdbc/BufferedJdbcAuditEventExecutor.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2015-2016 ForgeRock AS.
  * Portions Copyright 2016 Nomura Research Institute, Ltd.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.handlers.jdbc;
 
@@ -87,6 +88,7 @@ class BufferedJdbcAuditEventExecutor implements JdbcAuditEventExecutor {
         this.maxBatchedEvents = maxBatchedEvents;
     }
 
+    @Override
     public void flush() {
         try {
             while (!queue.isEmpty()) {

--- a/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandler.java
+++ b/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandler.java
@@ -119,6 +119,7 @@ public class JmsAuditEventHandler extends AuditEventHandlerBase {
      * @param auditEvent The event to convert to a JMS TextMessage and publish on the JMS Topic.
      * @return a promise with either a response or an exception
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> publishEvent(Context context, String auditTopic,
             JsonValue auditEvent) {
         try {

--- a/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JndiJmsContextManager.java
+++ b/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JndiJmsContextManager.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.audit.handlers.jms;
@@ -67,6 +67,7 @@ class JndiJmsContextManager implements JmsContextManager {
      * @return The {@link Topic JMS topic} to use for JMS publish/subscribe functionality.
      * @throws InternalServerErrorException If unable to retrieve the {@link Topic JMS topic}.
      */
+    @Override
     public Topic getTopic() throws InternalServerErrorException {
         try {
             if (topic == null) {
@@ -83,6 +84,7 @@ class JndiJmsContextManager implements JmsContextManager {
      * @return the {@link ConnectionFactory JMS connection factory} to use to connect to JMS services.
      * @throws InternalServerErrorException If unable to retrieve the {@link ConnectionFactory JMS connection factory}.
      */
+    @Override
     public ConnectionFactory getConnectionFactory() throws InternalServerErrorException {
         try {
             if (connectionFactory == null) {

--- a/commons/audit/handler-syslog/src/main/java/org/forgerock/audit/handlers/syslog/SyslogConnection.java
+++ b/commons/audit/handler-syslog/src/main/java/org/forgerock/audit/handlers/syslog/SyslogConnection.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2013 Cybernetica AS
  * Portions copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.handlers.syslog;
 
@@ -29,5 +30,6 @@ interface SyslogConnection extends AutoCloseable {
 
     void flush() throws IOException;
 
+    @Override
     void close();
 }

--- a/commons/audit/handler-syslog/src/main/java/org/forgerock/audit/handlers/syslog/SyslogPublisher.java
+++ b/commons/audit/handler-syslog/src/main/java/org/forgerock/audit/handlers/syslog/SyslogPublisher.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2013 Cybernetica AS
  * Portions copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.handlers.syslog;
 
@@ -35,5 +36,6 @@ interface SyslogPublisher extends AutoCloseable {
     /**
      * Closes the underlying connection.
      */
+    @Override
     void close();
 }

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
@@ -117,6 +117,7 @@ public class IWAModule implements AsyncServerAuthModule {
                     LOG.debug("IWAModule: IWA successful with username, {}", username);
 
                     clientSubject.getPrincipals().add(new Principal() {
+                        @Override
                         public String getName() {
                             return username;
                         }

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
@@ -175,6 +175,7 @@ public class WDSSO {
 
     private void authenticateToken(final byte[] kerberosToken) throws Exception {
         Subject.doAs(serviceSubject, new PrivilegedExceptionAction() {
+            @Override
             public Object run() throws Exception {
                 GSSContext context = GSSManager.getInstance().createContext((GSSCredential) null);
                 LOG.debug("IWA WDSSO: GSSContext created");

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WindowsDesktopSSOConfig.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WindowsDesktopSSOConfig.java
@@ -26,6 +26,7 @@
  * $Id: WindowsDesktopSSOConfig.java,v 1.3 2009/04/07 22:55:13 beomsuk Exp $
  *
  * Portions Copyrighted 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 
@@ -96,6 +97,7 @@ public class WindowsDesktopSSOConfig extends Configuration {
      * @param appName The app name.
      * @return Array of AppConfigurationEntry
      */
+    @Override
     public AppConfigurationEntry[] getAppConfigurationEntry(String appName) {
         if (appName.equals(DEFAULT_APP_NAME)) {
             Map<String, String> hashmap = new HashMap<>();
@@ -125,6 +127,7 @@ public class WindowsDesktopSSOConfig extends Configuration {
     /**
      * Do a config refresh.
      */
+    @Override
     public void refresh() {
         config.refresh();
     }

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/ServletJwtSessionModule.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.jaspi.modules.session.jwt;
@@ -92,6 +92,7 @@ public class ServletJwtSessionModule extends AbstractJwtSessionModule<Cookie> im
      * @param messageInfo The message info.
      * @return The cookie, or null.
      */
+    @Override
     public Cookie findJwtSessionCookie(MessageInfo messageInfo) {
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
         Set<Cookie> cookies = getCookies(request);

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/main/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceConfiguratorImpl.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/main/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceConfiguratorImpl.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions Copyrighted 2026 3A Systems, LLC
 */
 
 package org.forgerock.jaspi.modules.openid.resolvers.service;
@@ -46,6 +47,7 @@ public class OpenIdResolverServiceConfiguratorImpl implements OpenIdResolverServ
      * @param resolvers the configuration
      * @return false if any resolver configuration fails true otherwise
      */
+    @Override
     public boolean configureService(final OpenIdResolverService service, final List<Map<String, String>> resolvers) {
 
         if (resolvers == null || resolvers.size() < 1) {

--- a/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/main/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceImpl.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openid-connect-module/src/main/java/org/forgerock/jaspi/modules/openid/resolvers/service/OpenIdResolverServiceImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.jaspi.modules.openid.resolvers.service;
@@ -85,6 +86,7 @@ public class OpenIdResolverServiceImpl implements OpenIdResolverService {
      * @param issuer The name of the issuer of the Open Id Connect token to check
      * @return A resolver which can handle verification of the Open Id Connect token
      */
+    @Override
     public OpenIdResolver getResolverForIssuer(final String issuer) {
         return openIdResolvers.get(issuer);
     }
@@ -100,6 +102,7 @@ public class OpenIdResolverServiceImpl implements OpenIdResolverService {
      * @param keystorePassword password to enter the keystore
      * @return true if the resolver was configured successfully, false otherwise
      */
+    @Override
     public boolean configureResolverWithKey(final String issuer,
                                             final String keyAlias, final String keystoreLocation,
                                             final String keystoreType, final String keystorePassword) {
@@ -138,6 +141,7 @@ public class OpenIdResolverServiceImpl implements OpenIdResolverService {
      * @param sharedSecret The known-to-both-parties secret String
      * @return true if the resolver was configured successfully, false otherwise
      */
+    @Override
     public boolean configureResolverWithSecret(final String issuer, final String sharedSecret) {
 
         try {
@@ -158,6 +162,7 @@ public class OpenIdResolverServiceImpl implements OpenIdResolverService {
      * @param jwkUrl location from which to determine which public key to use
      * @return true if the resolver was configured successfully, false otherwise
      */
+    @Override
     public boolean configureResolverWithJWK(final String issuer,
                                             final URL jwkUrl) {
 
@@ -180,6 +185,7 @@ public class OpenIdResolverServiceImpl implements OpenIdResolverService {
      * @param configUrl location from which to determine which public key to use
      * @return true if the resolver was configured successfully, false otherwise
      */
+    @Override
     public boolean configureResolverWithWellKnownOpenIdConfiguration(final URL configUrl) {
 
         try {

--- a/commons/auth-filters/authn-filter/jaspi-runtime/src/main/java/org/forgerock/caf/authentication/framework/ResponseHandler.java
+++ b/commons/auth-filters/authn-filter/jaspi-runtime/src/main/java/org/forgerock/caf/authentication/framework/ResponseHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.caf.authentication.framework;
@@ -53,6 +54,7 @@ class ResponseHandler {
     private static final String QUALITY_PARAMETER = "q";
 
     private static final Comparator<MediaType> ACCEPT_QUALITY_COMPARATOR = new Comparator<MediaType>() {
+        @Override
         public int compare(MediaType o1, MediaType o2) {
             int comparison = getQuality(o2).compareTo(getQuality(o1));
             if (comparison == 0) {
@@ -155,6 +157,7 @@ class ResponseHandler {
                 MediaType.JSON_UTF_8,
                 MediaType.JSON_UTF_8.withoutParameters());
 
+        @Override
         public List<MediaType> handles() {
             return MEDIA_TYPES;
         }

--- a/commons/auth-filters/authz-filter/framework-api/src/main/java/org/forgerock/authz/filter/api/AuthorizationAttribute.java
+++ b/commons/auth-filters/authz-filter/framework-api/src/main/java/org/forgerock/authz/filter/api/AuthorizationAttribute.java
@@ -107,6 +107,7 @@ public final class AuthorizationAttribute<T> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         return "AuthorizationAttribute{key='" + key + "'}";
     }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/ManpagePost.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/ManpagePost.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.doc.maven.post;
@@ -60,6 +61,7 @@ public class ManpagePost extends AbstractDocbkxMojo {
      *
      * @throws MojoExecutionException   Failed to copy files.
      */
+    @Override
     public void execute() throws MojoExecutionException {
         File manPageOutputDir = new File(m.getDocbkxOutputDirectory(), "manpages");
         File generatedManPageDir = new File(manPageOutputDir.getAbsolutePath().replace(' ', '_'));

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/NoOp.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/NoOp.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.doc.maven.post;
@@ -40,6 +41,7 @@ public class NoOp extends AbstractDocbkxMojo {
     /**
      * Does no post-processing.
      */
+    @Override
     public void execute() {
         // Nothing to do.
     }

--- a/commons/geo/src/main/java/ru/org/openam/geo/servlets/Flag.java
+++ b/commons/geo/src/main/java/ru/org/openam/geo/servlets/Flag.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2020-2024 3A Systems LLC.
+ * Copyright 2020-2026 3A Systems LLC.
  */
 
 package ru.org.openam.geo.servlets;
@@ -34,6 +34,7 @@ public class Flag extends HttpServlet {
 		super();
 	}
 
+	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		if (request.getPathInfo()==null||!request.getPathInfo().matches("/[a-z]{2}\\.png"))
 			response.sendError(404);
@@ -53,6 +54,7 @@ public class Flag extends HttpServlet {
 		}
 	}
 
+	@Override
 	protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		doGet(request, response);
 	}

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingInputStream.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingInputStream.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.io;
@@ -62,6 +63,7 @@ public abstract class BranchingInputStream extends InputStream {
      * @throws IOException
      *             if an I/O exception occurs.
      */
+    @Override
     public abstract void close() throws IOException;
 
     /**

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
@@ -77,6 +77,7 @@ final class BranchingStreamWrapper extends BranchingInputStream {
         return new BranchingStreamWrapper(this, null);
     }
 
+    @Override
     public BranchingStreamWrapper copy() throws IOException {
         notClosed();
         return new BranchingStreamWrapper(this);

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/protocol/Cookie.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/protocol/Cookie.java
@@ -98,6 +98,7 @@ public class Cookie {
         }
       }
 
+      @Override
       public String toString() {
         return name().toLowerCase();
       }

--- a/commons/http-framework/examples/descriptor-example/src/main/java/org/forgerock/http/example/DescribedOauth2Endpoint.java
+++ b/commons/http-framework/examples/descriptor-example/src/main/java/org/forgerock/http/example/DescribedOauth2Endpoint.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.http.example;
@@ -82,6 +83,7 @@ public class DescribedOauth2Endpoint implements DescribableHandler {
     public DescribedOauth2Endpoint() {
         this.router = new Router();
         router.addRoute(requestUriMatcher(EQUALS, "authorize"), new Handler() {
+            @Override
             public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
                 if (!"GET".equals(request.getMethod())) {
                     return newResultPromise(new Response(METHOD_NOT_ALLOWED));
@@ -127,6 +129,7 @@ public class DescribedOauth2Endpoint implements DescribableHandler {
             }
         });
         router.addRoute(requestUriMatcher(EQUALS, "login"), new Handler() {
+            @Override
             public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
                 String authValue = getAuthorizationHeader(request);
                 if (authValue != null && authValue.startsWith("Basic ")) {
@@ -144,6 +147,7 @@ public class DescribedOauth2Endpoint implements DescribableHandler {
             }
         });
         router.addRoute(requestUriMatcher(EQUALS, "token"), new Handler() {
+            @Override
             public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
                 if (!"POST".equals(request.getMethod())) {
                     return newResultPromise(new Response(METHOD_NOT_ALLOWED));
@@ -179,6 +183,7 @@ public class DescribedOauth2Endpoint implements DescribableHandler {
             }
         });
         router.addRoute(requestUriMatcher(EQUALS, "api"), new Handler() {
+            @Override
             public Promise<Response, NeverThrowsException> handle(Context context, Request request) {
                 if (!"GET".equals(request.getMethod())) {
                     return newResultPromise(new Response(METHOD_NOT_ALLOWED));

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2020-2025 3A Systems LLC.
+ * Copyright 2020-2026 3A Systems LLC.
  */
 
 package ru.org.openam.httpdump;
@@ -81,10 +81,12 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
             this.is = is;
         }
 
+        @Override
         public int read() throws IOException {
             return is.read();
         }
 
+        @Override
         public synchronized void mark(int i) {
             throw new RuntimeException(new IOException("mark/reset not supported"));
         }

--- a/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/JsonDecryptFunction.java
+++ b/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/JsonDecryptFunction.java
@@ -1,3 +1,20 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyrighted [year] [name of copyright owner]".
+ *
+ * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
+ */
+
 package org.forgerock.json.crypto;
 
 import org.forgerock.json.JsonValue;
@@ -17,6 +34,7 @@ public class JsonDecryptFunction
     this.decryptor = ((JsonDecryptor)Reject.checkNotNull(decryptor));
   }
   
+  @Override
   protected Object traverseMap(JsonValue value)
   {
     if (JsonCrypto.isJsonCrypto(value))

--- a/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/JsonEncryptFunction.java
+++ b/commons/json-crypto/core/src/main/java/org/forgerock/json/crypto/JsonEncryptFunction.java
@@ -1,3 +1,20 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions Copyrighted [year] [name of copyright owner]".
+ *
+ * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
+ */
+
 package org.forgerock.json.crypto;
 
 import org.forgerock.json.JsonValue;
@@ -14,6 +31,7 @@ public class JsonEncryptFunction
     this.encryptor = ((JsonEncryptor)Reject.checkNotNull(encryptor));
   }
   
+  @Override
   public JsonValue apply(JsonValue value)
     throws JsonCryptoException
   {

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonPointer.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonPointer.java
@@ -311,18 +311,22 @@ public class JsonPointer implements Iterable<String> {
     /**
      * Returns an iterator over the pointer's reference tokens.
      */
+    @Override
     public Iterator<String> iterator() {
         return new Iterator<String>() {
             int cursor = 0;
+            @Override
             public boolean hasNext() {
                 return cursor < tokens.length;
             }
+            @Override
             public String next() {
                 if (cursor >= tokens.length) {
                     throw new NoSuchElementException();
                 }
                 return tokens[cursor++];
             }
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
@@ -872,15 +872,19 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
                     }
                     return result;
                 }
+                @Override
                 public Iterator<String> iterator() {
                     return new Iterator<String>() {
                         Iterator<Integer> i = range.iterator();
+                        @Override
                         public boolean hasNext() {
                             return i.hasNext();
                         }
+                        @Override
                         public String next() {
                             return i.next().toString();
                         }
+                        @Override
                         public void remove() {
                             throw new UnsupportedOperationException();
                         }
@@ -902,18 +906,22 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
      * Note: calls to the {@code next()} method may throw the runtime {@link JsonException}
      * if any transformers fail to execute.
      */
+    @Override
     public Iterator<JsonValue> iterator() {
         if (isList()) { // optimize for list
             return new Iterator<JsonValue>() {
                 int cursor = 0;
                 Iterator<Object> i = asList().iterator();
+                @Override
                 public boolean hasNext() {
                     return i.hasNext();
                 }
+                @Override
                 public JsonValue next() {
                     Object element = i.next();
                     return new JsonValue(element, pointer.child(cursor++), transformers);
                 }
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException();
                 }
@@ -921,12 +929,15 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         } else {
             return new Iterator<JsonValue>() {
                 Iterator<String> i = keys().iterator();
+                @Override
                 public boolean hasNext() {
                     return i.hasNext();
                 }
+                @Override
                 public JsonValue next() {
                     return get(i.next());
                 }
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException();
                 }

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValueList.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValueList.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.fluent;
@@ -43,6 +44,7 @@ public class JsonValueList<E> extends AbstractList<E> implements JsonValueWrappe
         this.jsonValue = jsonValue.expect(List.class);
     }
 
+    @Override
     public JsonValue unwrap() {
         return jsonValue;
     }

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValueMap.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValueMap.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright © 2011 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.fluent;
@@ -44,6 +45,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
         this.jsonValue = jsonValue.expect(Map.class);
     }
 
+    @Override
     public JsonValue unwrap() {
         return jsonValue;
     }
@@ -51,6 +53,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Returns the number of key-value mappings in this map.
      */
+    @Override
     public int size() {
         return jsonValue.size();
     }
@@ -58,6 +61,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Returns {@code true} if this map contains no key-value mappings.
      */
+    @Override
     public boolean isEmpty() {
         return (jsonValue.size() == 0);
     }
@@ -68,6 +72,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      * @param key key whose presence in this map is to be tested.
      * @return {@code true} if this map contains a mapping for the specified key.
      */
+    @Override
     public boolean containsKey(Object key) {
         return (key != null && key instanceof String && jsonValue.isDefined((String)key));
     }
@@ -78,6 +83,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      * @param value value whose presence in this map is to be tested.
      * @return {@code true} if this map maps one or more keys to the specified value.
      */
+    @Override
     public boolean containsValue(Object value) {
         return jsonValue.contains(value);
     }
@@ -89,6 +95,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      * @param key the key whose associated value is to be returned.
      * @return the value to which the specified key is mapped, or {@code null}.
      */
+    @Override
     public Object get(Object key) {
         Object result = null;
         if (key != null && key instanceof String) {
@@ -104,6 +111,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      * @param value value to be associated with the specified key.
      * @return the previous value associated with key, or {@code null} if there was no mapping for key.
      */
+    @Override
     public Object put(String key, Object value) {
         Object result = get(key);
         jsonValue.put(key, value);
@@ -116,6 +124,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      * @param key key whose mapping is to be removed from the map.
      * @return the previous value associated with key, or {@code null} if there was no mapping for key.
      */
+    @Override
     public Object remove(Object key) {
         Object result = get(key);
         if (key instanceof String) {
@@ -129,6 +138,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
      *
      * @param m mappings to be stored in this map.
      */
+    @Override
     public void putAll(Map<? extends String, ? extends Object> m) {
         for (Map.Entry<? extends String, ? extends Object> entry : m.entrySet()) {
             jsonValue.put(entry.getKey(), entry.getValue());
@@ -138,6 +148,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Removes all of the mappings from this map.
      */
+    @Override
     public void clear() {
         jsonValue.clear();
     }
@@ -145,6 +156,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Returns a {@code Set} view of the keys contained in this map.
      */
+    @Override
     public Set<String> keySet() {
         return jsonValue.keys();
     }
@@ -152,6 +164,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Returns a Collection view of the values contained in this map.
      */
+    @Override
     public Collection<Object> values() {
         ArrayList<Object> result = new ArrayList<Object>(size());
         for (JsonValue jv : jsonValue) {
@@ -163,6 +176,7 @@ public class JsonValueMap implements JsonValueWrapper, Map<String, Object> {
     /**
      * Returns a {@code Set} view of the mappings contained in this map.
      */
+    @Override
     public Set<Map.Entry<String, Object>> entrySet() {
         HashSet<Map.Entry<String, Object>> result = new HashSet<Map.Entry<String, Object>>(size());
         for (String key : jsonValue.keys()) {

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/RangeSet.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/RangeSet.java
@@ -62,15 +62,18 @@ class RangeSet extends AbstractSet<String> implements Set<String>, Cloneable, Se
     public Iterator<String> iterator() {
         return new Iterator<String>() {
             int cursor = start;
+            @Override
             public boolean hasNext() {
                 return cursor <= end;
             }
+            @Override
             public String next() {
                 if (cursor > end) {
                     throw new NoSuchElementException();
                 }
                 return Integer.toString(cursor++);
             }
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }

--- a/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
+++ b/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
@@ -165,6 +165,7 @@ public final class Main {
             validateDirectory(schemaFile);
             FileFilter filter = new FileFilter() {
 
+                @Override
                 public boolean accept(File f) {
                     return (f.isDirectory()) || (f.getName().endsWith(".json"));
                 }

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/BooleanTypeValidator.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/BooleanTypeValidator.java
@@ -54,6 +54,7 @@ public class BooleanTypeValidator extends Validator {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void validate(Object node, JsonPointer at, ErrorHandler handler) throws SchemaException {
         if (node instanceof Boolean) {
             return;

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/IntegerTypeValidator.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/IntegerTypeValidator.java
@@ -130,6 +130,7 @@ public class IntegerTypeValidator extends Validator {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void validate(Object node, JsonPointer at, ErrorHandler handler) throws SchemaException {
         if (node instanceof Number) {
             Number number = (Long) node;

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/NumberTypeValidator.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/NumberTypeValidator.java
@@ -131,6 +131,7 @@ public class NumberTypeValidator extends Validator {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void validate(Object node, JsonPointer at, ErrorHandler handler) throws SchemaException {
         if (node instanceof Number) {
             Number nodeValue = (Number) node;

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/EcJWK.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/EcJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwk;
@@ -191,6 +192,7 @@ public class EcJWK extends JWK {
      * Prints the JWK as a String json object.
      * @return a json string object
      */
+    @Override
     public String toJsonString() {
         return super.toString();
     }

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/OctJWK.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/OctJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwk;
@@ -105,6 +106,7 @@ public class OctJWK extends JWK {
      * Prints the JWK as a json string.
      * @return json string
      */
+    @Override
     public String toJsonString() {
         return super.toString();
     }

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/RsaJWK.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwk/RsaJWK.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwk;
@@ -555,6 +556,7 @@ public class RsaJWK extends JWK {
      * Prints the RsaJWK object as a json string.
      * @return json string
      */
+    @Override
     public String toJsonString() {
         return super.toString();
     }

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSet.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSet.java
@@ -500,6 +500,7 @@ public class JwtClaimsSet extends JWObject implements Payload {
      *
      * @return A JSON string.
      */
+    @Override
     public String build() {
         return toString();
     }

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/AbstractOSGiFrameworkService.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/AbstractOSGiFrameworkService.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.commons.launcher;
@@ -78,6 +79,7 @@ public abstract class AbstractOSGiFrameworkService implements OSGiFramework {
 
     protected abstract void registerServices(BundleContext bundleContext) throws Exception;
 
+    @Override
     public void start() throws Exception {
         // Create an instance of the framework.
         FrameworkFactory factory = ServiceLoader.load(FrameworkFactory.class).iterator().next();
@@ -95,6 +97,7 @@ public abstract class AbstractOSGiFrameworkService implements OSGiFramework {
             registerServices(framework.get().getBundleContext());
 
             Callable<Void> container = new Callable<Void>() {
+                @Override
                 public Void call() throws Exception {
                     FrameworkEvent event = null;
                     do {
@@ -127,6 +130,7 @@ public abstract class AbstractOSGiFrameworkService implements OSGiFramework {
         }
     }
     
+    @Override
     public void stop() throws Exception {
         Framework fw = framework.getAndSet(null);
         if (null != fw) {

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandler.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/BundleHandler.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.commons.launcher;
@@ -88,6 +89,7 @@ public class BundleHandler {
         return actions;
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("BundleHandler[");
         sb.append("url: ").append(bundleUrl);

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/ConfigurationUtil.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/ConfigurationUtil.java
@@ -126,6 +126,7 @@ public class ConfigurationUtil {
 
     static { 
     	URL.setURLStreamHandlerFactory(protocol -> "jar".equals(protocol) ? new URLStreamHandler() {
+    	    @Override
     	    protected URLConnection openConnection(URL url) throws IOException {
     	        return new JarURLConnection(url) {
     	        	

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
@@ -146,6 +146,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
     public OSGiFrameworkService() {
 
         propertyAccessor = new PropertyAccessor() {
+            @Override
             public <T> T get(String name) {
                 Object value = null;
                 if (null != bootParameters) {
@@ -175,6 +176,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         };
 
         transformer = new JsonTransformer() {
+            @Override
             public void transform(JsonValue value) throws JsonException {
                 if (null != value && value.isString()) {
                     value.setObject(ConfigurationUtil.substVars(value.asString(), propertyAccessor));
@@ -223,6 +225,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         this.configFile = configFile;
     }
 
+    @Override
     protected boolean isVerbose() {
         return verbose;
     }
@@ -250,6 +253,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         this.bootParameters = bootParameters;
     }
 
+    @Override
     public boolean isNewThread() {
         return newThread;
     }
@@ -259,11 +263,13 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         newThread = value;
     }
 
+    @Override
     protected long getStopTimeout() {
         return 0;
     }
 
     @SuppressWarnings({ "unchecked" })
+    @Override
     public void init(String[] arguments) throws Exception {
         CmdLineParser parser = new CmdLineParser(this);
 
@@ -293,14 +299,17 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         init();
     }
 
+    @Override
     public void destroy() {
 
     }
 
+    @Override
     public Bundle getSystemBundle() {
         return getFramework();
     }
 
+    @Override
     public void init() throws Exception {
         if (null == bootParameters) {
             bootParameters = new HashMap<String, Object>();
@@ -388,6 +397,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
                 || ((enableHook instanceof String) && !((String) enableHook)
                         .equalsIgnoreCase("false"))) {
             Runtime.getRuntime().addShutdownHook(new Thread("Felix Shutdown Hook") {
+                @Override
                 public void run() {
                     try {
                         OSGiFrameworkService.this.stop();
@@ -402,6 +412,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
 
     }
 
+    @Override
     protected void registerServices(BundleContext bundleContext) throws Exception {
         Dictionary<String, String> properties = new Hashtable<String, String>(4);
         properties.put(Constants.SERVICE_VENDOR, "Open Identity Platform Community");
@@ -412,6 +423,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
                 properties);
     }
 
+    @Override
     protected Map<String, String> getConfigurationProperties() {
         if (null == configurationProperties) {
             configurationProperties = new HashMap<String, String>();
@@ -435,6 +447,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
         this.launcherConfiguration = launcherConfiguration;
     }
 
+    @Override
     protected List<BundleHandler> listBundleHandlers(BundleContext context)
             throws MalformedURLException {
         JsonValue bundle = getLauncherConfiguration().get("bundle");

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/transform/LocalizableByteArrayProperty.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/transform/LocalizableByteArrayProperty.java
@@ -102,6 +102,7 @@ class LocalizableByteArrayProperty extends ByteArrayProperty implements Localiza
      *
      * @return Default value or {@code null}
      */
+    @Override
     public String getDefault() {
         return defaultValue;
     }

--- a/commons/rest/json-resource-http/src/main/java/org/forgerock/json/resource/http/HttpUtils.java
+++ b/commons/rest/json-resource-http/src/main/java/org/forgerock/json/resource/http/HttpUtils.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.json.resource.http;
@@ -926,18 +926,22 @@ public final class HttpUtils {
             this.request = request;
         }
 
+        @Override
         public InputStream getInputStream() throws IOException {
             return request.getEntity().getRawContentInputStream();
         }
 
+        @Override
         public OutputStream getOutputStream() throws IOException {
             return null;
         }
 
+        @Override
         public String getContentType() {
             return request.getHeaders().getFirst(ContentTypeHeader.class);
         }
 
+        @Override
         public String getName() {
             return "HttpServletRequestDataSource";
         }

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/AbstractConnectionWrapper.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/AbstractConnectionWrapper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -69,6 +70,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ActionResponse action(Context context, ActionRequest request) throws ResourceException {
         return connection.action(transform(context), request);
     }
@@ -78,6 +80,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ActionResponse, ResourceException> actionAsync(Context context, ActionRequest request) {
         return connection.actionAsync(transform(context), request);
     }
@@ -87,6 +90,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public void close() {
         connection.close();
     }
@@ -96,6 +100,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ResourceResponse create(Context context, CreateRequest request) throws ResourceException {
         return connection.create(transform(context), request);
     }
@@ -105,6 +110,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> createAsync(Context context, CreateRequest request) {
         return connection.createAsync(transform(context), request);
     }
@@ -114,6 +120,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ResourceResponse delete(Context context, DeleteRequest request) throws ResourceException {
         return connection.delete(transform(context), request);
     }
@@ -123,6 +130,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> deleteAsync(Context context, DeleteRequest request) {
         return connection.deleteAsync(transform(context), request);
     }
@@ -132,6 +140,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public boolean isClosed() {
         return connection.isClosed();
     }
@@ -141,6 +150,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public boolean isValid() {
         return connection.isValid();
     }
@@ -150,6 +160,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ResourceResponse patch(Context context, PatchRequest request) throws ResourceException {
         return connection.patch(transform(context), request);
     }
@@ -159,6 +170,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> patchAsync(Context context, PatchRequest request) {
         return connection.patchAsync(transform(context), request);
     }
@@ -168,6 +180,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public QueryResponse query(Context context, QueryRequest request, QueryResourceHandler handler)
             throws ResourceException {
         return connection.query(transform(context), request, handler);
@@ -178,6 +191,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public QueryResponse query(Context context, QueryRequest request,
             Collection<? super ResourceResponse> results) throws ResourceException {
         return connection.query(transform(context), request, results);
@@ -188,6 +202,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<QueryResponse, ResourceException> queryAsync(Context context,
             QueryRequest request, QueryResourceHandler handler) {
         return connection.queryAsync(transform(context), request, handler);
@@ -198,6 +213,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ResourceResponse read(Context context, ReadRequest request) throws ResourceException {
         return connection.read(transform(context), request);
     }
@@ -207,6 +223,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> readAsync(Context context, ReadRequest request) {
         return connection.readAsync(transform(context), request);
     }
@@ -216,6 +233,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public ResourceResponse update(Context context, UpdateRequest request) throws ResourceException {
         return connection.update(transform(context), request);
     }
@@ -225,6 +243,7 @@ public abstract class AbstractConnectionWrapper<C extends Connection>
      * <p>
      * The default implementation is to delegate.
      */
+    @Override
     public Promise<ResourceResponse, ResourceException> updateAsync(Context context, UpdateRequest request) {
         return connection.updateAsync(transform(context), request);
     }

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Connection.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Connection.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -76,6 +77,7 @@ public interface Connection extends Closeable {
      * Calling {@code close} on a connection that is already closed has no
      * effect.
      */
+    @Override
     void close();
 
     /**

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Resources.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Resources.java
@@ -72,6 +72,7 @@ public final class Resources {
             return newInternalConnection(handler);
         }
 
+        @Override
         public Promise<Connection, ResourceException> getConnectionAsync() {
             return newSuccessfulPromise(getConnection());
         }

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Responses.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/Responses.java
@@ -241,6 +241,7 @@ public final class Responses {
             }
         }
 
+        @Override
         public Promise<ResourceResponse, ResourceException> asPromise() {
             return Promises.<ResourceResponse, ResourceException>newResultPromise(this);
         }

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/SortKey.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/SortKey.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS. All rights reserved.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.resource;
@@ -156,6 +157,7 @@ public final class SortKey {
      *
      * @return The string representation of this sort key.
      */
+    @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(isAscendingOrder ? '+' : '-');

--- a/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleEmailService.java
+++ b/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleEmailService.java
@@ -124,6 +124,7 @@ final class ExampleEmailService implements SingletonResourceProvider {
 
         Session session = Session.getInstance(props, new Authenticator() {
 
+            @Override
             protected PasswordAuthentication getPasswordAuthentication() {
                 return new PasswordAuthentication(username, password);
             }

--- a/commons/selfservice/stages/src/main/java/org/forgerock/selfservice/stages/tokenhandlers/JwtTokenHandlerConfig.java
+++ b/commons/selfservice/stages/src/main/java/org/forgerock/selfservice/stages/tokenhandlers/JwtTokenHandlerConfig.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.selfservice.stages.tokenhandlers;
@@ -56,6 +57,7 @@ public final class JwtTokenHandlerConfig implements SnapshotTokenConfig {
      *
      * @return the type
      */
+    @Override
     public String getType() {
         return TYPE;
     }

--- a/commons/util/util/src/main/java/org/forgerock/json/JsonPatch.java
+++ b/commons/util/util/src/main/java/org/forgerock/json/JsonPatch.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json;
@@ -64,6 +65,7 @@ public final class JsonPatch {
      */
     private static final JsonPatchValueTransformer DEFAULT_TRANSFORM =
         new JsonPatchValueTransformer() {
+            @Override
             public Object getTransformedValue(JsonValue target, JsonValue op) {
                 if (op.get(JsonPatch.VALUE_PTR) != null) {
                     return op.get(JsonPatch.VALUE_PTR).getObject();

--- a/commons/util/util/src/main/java/org/forgerock/util/i18n/LocalizableString.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/i18n/LocalizableString.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.util.i18n;
 
@@ -125,6 +126,7 @@ public class LocalizableString {
      * The default toString method. No translation is applied.
      * @return the untranslated string value
      */
+    @Override
     public String toString() {
         return defaultValue == null ? value : "[" + value + "], default [" + defaultValue + "]";
     }

--- a/commons/util/util/src/main/java/org/forgerock/util/thread/ExecutorServiceFactory.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/thread/ExecutorServiceFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.util.thread;
 
@@ -186,6 +187,7 @@ public class ExecutorServiceFactory {
     private void registerShutdown(final ExecutorService service) {
         shutdownManager.addShutdownListener(
                 new ShutdownListener() {
+                    @Override
                     public void shutdown() {
                         service.shutdownNow();
                     }
@@ -206,6 +208,7 @@ public class ExecutorServiceFactory {
             this.name = name;
         }
 
+        @Override
         public Thread newThread(Runnable r) {
             return new Thread(r, name + "-" +  count.getAndIncrement());
         }

--- a/commons/xcite-maven-plugin/src/main/java/org/forgerock/maven/plugins/xcite/Citation.java
+++ b/commons/xcite-maven-plugin/src/main/java/org/forgerock/maven/plugins/xcite/Citation.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.maven.plugins.xcite;
@@ -317,6 +318,7 @@ public class Citation {
      *
      * @return The string representation of this citation.
      */
+    @Override
     public String toString() {
         String start =
                 (isNullOrEmpty(getStart()) ? "" : getDelimiter() + getStart());

--- a/guice/core/src/main/java/org/forgerock/guice/core/ServiceLoaderWrapper.java
+++ b/guice/core/src/main/java/org/forgerock/guice/core/ServiceLoaderWrapper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.guice.core;
@@ -64,6 +65,7 @@ public class ServiceLoaderWrapper {
          *
          * @return {@inheritDoc}
          */
+        @Override
         public Iterator<T> iterator() {
             return serviceLoader.iterator();
         }

--- a/guice/servlet/src/main/java/org/forgerock/guice/core/GuiceInitialisationFilter.java
+++ b/guice/servlet/src/main/java/org/forgerock/guice/core/GuiceInitialisationFilter.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.guice.core;
@@ -39,6 +39,7 @@ public final class GuiceInitialisationFilter implements ServletContextListener {
      *
      * @param servletContextEvent {@inheritDoc}
      */
+    @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
     		try {
 	        ServletContext servletContext = servletContextEvent.getServletContext();
@@ -58,6 +59,7 @@ public final class GuiceInitialisationFilter implements ServletContextListener {
      *
      * @param servletContextEvent {@inheritDoc}
      */
+    @Override
     public void contextDestroyed(ServletContextEvent servletContextEvent) {
     }
 }

--- a/guice/test/src/main/java/org/forgerock/guice/core/GuiceTestCase.java
+++ b/guice/test/src/main/java/org/forgerock/guice/core/GuiceTestCase.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.guice.core;
@@ -56,6 +57,7 @@ public abstract class GuiceTestCase implements Module {
 
         final GuiceTestCase testCase = this;
         Module overrideModule = new Module() {
+            @Override
             public void configure(Binder binder) {
                 testCase.configureOverrideBindings(binder);
             }
@@ -79,6 +81,7 @@ public abstract class GuiceTestCase implements Module {
      * A default, empty implementation is provided as the test may not have any of its own objects to bind.
      * @param binder The Guice binder.
      */
+    @Override
     public void configure(Binder binder) {
     }
 

--- a/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizableMessage.java
+++ b/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizableMessage.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2009 Sun Microsystems, Inc.
  *      Portions copyright 2011-2012 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.i18n;
@@ -193,6 +194,7 @@ public final class LocalizableMessage implements CharSequence, Formattable,
      *             If the {@code index} argument is negative or not less than
      *             {@code length()}.
      */
+    @Override
     public char charAt(final int index) {
         return charAt(Locale.getDefault(), index);
     }
@@ -226,6 +228,7 @@ public final class LocalizableMessage implements CharSequence, Formattable,
      * @return A negative integer, zero, or a positive integer as this object is
      *         less than, equal to, or greater than the specified object.
      */
+    @Override
     public int compareTo(final LocalizableMessage message) {
         return toString().compareTo(message.toString());
     }
@@ -287,6 +290,7 @@ public final class LocalizableMessage implements CharSequence, Formattable,
      *             href="../util/Formatter.html#detail">Details</a> section of
      *             the formatter class specification.
      */
+    @Override
     public void formatTo(final Formatter formatter, final int flags,
             final int width, final int precision) {
         // Ignores flags, width and precision for now.
@@ -314,6 +318,7 @@ public final class LocalizableMessage implements CharSequence, Formattable,
      * @return The length of the {@code String} representation of this message
      *         in the default locale.
      */
+    @Override
     public int length() {
         return length(Locale.getDefault());
     }
@@ -390,6 +395,7 @@ public final class LocalizableMessage implements CharSequence, Formattable,
      *             is greater than {@code length()}, or if {@code start} is
      *             greater than {@code end}.
      */
+    @Override
     public CharSequence subSequence(final int start, final int end) {
         return subSequence(Locale.getDefault(), start, end);
     }

--- a/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizableMessageBuilder.java
+++ b/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizableMessageBuilder.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2007-2009 Sun Microsystems, Inc.
  *      Portions copyright 2011 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.i18n;
@@ -103,6 +104,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      *            The character to be appended.
      * @return A reference to this message builder.
      */
+    @Override
     public LocalizableMessageBuilder append(final char c) {
         return append(LocalizableMessage.valueOf(c));
     }
@@ -116,6 +118,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      * @throws NullPointerException
      *             If {@code cs} was {@code null}.
      */
+    @Override
     public LocalizableMessageBuilder append(final CharSequence cs) {
         if (cs == null) {
             throw new NullPointerException("cs was null");
@@ -150,6 +153,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      * @throws NullPointerException
      *             If {@code cs} was {@code null}.
      */
+    @Override
     public LocalizableMessageBuilder append(final CharSequence cs,
             final int start, final int end) {
         return append(cs.subSequence(start, end));
@@ -208,6 +212,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      *             If the {@code index} argument is negative or not less than
      *             {@code length()}.
      */
+    @Override
     public char charAt(final int index) {
         return charAt(Locale.getDefault(), index);
     }
@@ -239,6 +244,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      * @return The length of the {@code String} representation of this message
      *         builder in the default locale.
      */
+    @Override
     public int length() {
         return length(Locale.getDefault());
     }
@@ -277,6 +283,7 @@ public final class LocalizableMessageBuilder implements Appendable,
      *             is greater than {@code length()}, or if {@code start} is
      *             greater than {@code end}.
      */
+    @Override
     public CharSequence subSequence(final int start, final int end) {
         return subSequence(Locale.getDefault(), start, end);
     }

--- a/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizedIllegalArgumentException.java
+++ b/i18n-framework/core/src/main/java/org/forgerock/i18n/LocalizedIllegalArgumentException.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2009 Sun Microsystems, Inc.
  *      Portions copyright 2011 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.i18n;
@@ -69,6 +70,7 @@ public class LocalizedIllegalArgumentException extends IllegalArgumentException
     /**
      * {@inheritDoc}
      */
+    @Override
     public final LocalizableMessage getMessageObject() {
         return this.message;
     }

--- a/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
+++ b/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
@@ -549,6 +549,7 @@ abstract class AbstractGenerateMessagesMojo extends AbstractMojo {
     /**
      * {@inheritDoc}
      */
+    @Override
     public final void execute() throws MojoExecutionException {
         final File resourceDirectory = getResourceDirectory();
 

--- a/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/CleanMessagesMojo.java
+++ b/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/CleanMessagesMojo.java
@@ -61,6 +61,7 @@ public final class CleanMessagesMojo extends AbstractMojo {
         /**
          * {@inheritDoc}
          */
+        @Override
         public void run() {
             // Cache the keys that we want to check so that we avoid excessive
             // contention on the CHM.
@@ -138,6 +139,7 @@ public final class CleanMessagesMojo extends AbstractMojo {
      * {@inheritDoc}
      */
     // @Checkstyle:ignore
+    @Override
     public void execute() throws MojoExecutionException {
         if (!sourceDirectory.exists()) {
             throw new MojoExecutionException("Source directory "

--- a/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/MessagePropertyKey.java
+++ b/i18n-framework/maven-plugin/src/main/java/org/forgerock/i18n/maven/MessagePropertyKey.java
@@ -13,6 +13,7 @@
  *
  *      Copyright 2008 Sun Microsystems, Inc.
  *      Portions copyright 2011 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.i18n.maven;
@@ -106,6 +107,7 @@ final class MessagePropertyKey implements Comparable<MessagePropertyKey> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo(final MessagePropertyKey k) {
         if (ordinal == k.ordinal) {
             return name.compareTo(k.name);

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
@@ -351,6 +351,7 @@ public class ArtifactItem
      * 
      * @return result string
      */
+    @Override
     public final String toString()
     {
         if (this.classifier == null)

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/CleanExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/CleanExternalDependencyMojo.java
@@ -36,6 +36,7 @@ public class CleanExternalDependencyMojo extends AbstractExternalDependencyMojo
     {
     }
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         try

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/DeployExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/DeployExternalDependencyMojo.java
@@ -77,6 +77,7 @@ public class DeployExternalDependencyMojo extends
      */
     private boolean offline;
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         // update base configuration parameters

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
@@ -81,6 +81,7 @@ public class InstallExternalDependencyMojo extends
      */
     protected boolean createChecksum = true;
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         try

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
@@ -133,6 +133,7 @@ public class ResolveExternalDependencyMojo extends
      */
     private Integer downloadRetryDelay;
     
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         try

--- a/persistit/examples/FindFile/FindFile.java
+++ b/persistit/examples/FindFile/FindFile.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 import java.awt.BorderLayout;
@@ -114,18 +115,21 @@ public class FindFile extends JPanel {
         this.persistit = persistit;
 
         searchButton.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ae) {
                 doSearch();
             }
         });
 
         loadButton.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ae) {
                 doLoad();
             }
         });
 
         clearButton.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ae) {
                 doClear();
             }
@@ -216,6 +220,7 @@ public class FindFile extends JPanel {
         // performed in a separate thread.
         //
         Thread workerThread = new Thread() {
+            @Override
             public void run() {
                 if (suffix.length() > prefix.length()) {
                     //
@@ -248,6 +253,7 @@ public class FindFile extends JPanel {
         loadButton.setEnabled(false);
 
         Thread workerThread = new Thread(new Runnable() {
+            @Override
             public void run() {
                 loadFileNames(fileName);
             }
@@ -262,6 +268,7 @@ public class FindFile extends JPanel {
      */
     private void doClear() {
         Thread workerThread = new Thread(new Runnable() {
+            @Override
             public void run() {
                 resetFileNames();
             }
@@ -327,6 +334,7 @@ public class FindFile extends JPanel {
             setEnabled(searchField, true);
 
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     int size = selectedFileNames.size();
                     for (int index = 0; index < size; index++) {
@@ -511,6 +519,7 @@ public class FindFile extends JPanel {
      */
     private void adjustProgressBar(final int value, final int maximum) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 progressBar.setMaximum(maximum);
                 progressBar.setValue(value);
@@ -532,6 +541,7 @@ public class FindFile extends JPanel {
      */
     private void setEnabled(final JComponent component, final boolean enabled) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 component.setEnabled(enabled);
             }
@@ -564,12 +574,14 @@ public class FindFile extends JPanel {
         // the containing JFrame.
         //
         frame.addWindowListener(new WindowAdapter() {
+            @Override
             public void windowClosed(WindowEvent we) {
                 //
                 // Persistit.close may take several seconds to complete. Best
                 // not to do it on the Swing event dispatch thread.
                 //
                 Thread workerThread = new Thread(new Runnable() {
+                    @Override
                     public void run() {
                         try {
                             System.out.println("Closing Persistit");

--- a/persistit/examples/SimpleTransaction/SimpleTransaction.java
+++ b/persistit/examples/SimpleTransaction/SimpleTransaction.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 import java.io.PrintStream;
@@ -143,10 +144,12 @@ public class SimpleTransaction implements Runnable {
         }
     }
 
+    @Override
     public String toString() {
         return "SimpleTransaction #" + _threadIndex;
     }
 
+    @Override
     public void run() {
         try {
             Exchange accountEx = new Exchange(persistit, "txndemo", "account", true);
@@ -253,6 +256,7 @@ public class SimpleTransaction implements Runnable {
             _ex = ex;
         }
 
+        @Override
         public void runTransaction() throws PersistitException {
             _ex.clear().append(Key.BEFORE);
             //

--- a/script/common/src/main/java/org/forgerock/script/ScriptName.java
+++ b/script/common/src/main/java/org/forgerock/script/ScriptName.java
@@ -100,6 +100,7 @@ public final class ScriptName {
         return result;
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(name).append(':').append(type);
         if (null != revision) {

--- a/script/common/src/main/java/org/forgerock/script/engine/AbstractScriptEngine.java
+++ b/script/common/src/main/java/org/forgerock/script/engine/AbstractScriptEngine.java
@@ -164,6 +164,7 @@ public abstract class AbstractScriptEngine implements ScriptEngine {
     // }
 
     /** {@inheritDoc} */
+    @Override
     public Object compileObject(final Context context, Object value) {
         // JsonValue temp = new JsonValue(value);
         // temp.getTransformers().add(getOperationParameter(context));

--- a/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
@@ -21,6 +21,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.registry;
@@ -186,6 +187,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
 
     // ScriptRegistry Methods
 
+    @Override
     public Set<ScriptName> listScripts() {
         return Collections.unmodifiableSet(cache.keySet());
     }
@@ -194,10 +196,12 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         return takeScript(new ScriptName(name, SourceUnit.AUTO_DETECT));
     }
 
+    @Override
     public ScriptEngine getEngineByName(String shortName) {
         return findScriptEngine(shortName);
     }
 
+    @Override
     public ScriptEntry takeScript(JsonValue script) throws ScriptException {
         if (null == script || script.expect(Map.class).isNull()) {
             throw new NullPointerException("Null scriptValue");
@@ -249,6 +253,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         return scriptEntry;
     }
 
+    @Override
     public synchronized ScriptEntry takeScript(ScriptName name) throws ScriptException {
         LibraryRecord rec = cache.get(name);
         if (null != rec) {
@@ -428,14 +433,17 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
 
         // START CompilationHandler
 
+        @Override
         public ScriptSource getScriptSource() {
             return source;
         }
 
+        @Override
         public ClassLoader getParentClassLoader() {
             return ScriptRegistryImpl.this.getRegistryLevelScriptClassLoader();
         }
 
+        @Override
         public void setCompiledScript(CompiledScript script) {
             int type = null != target ? ScriptEvent.MODIFIED : ScriptEvent.REGISTERED;
             target = script;
@@ -443,6 +451,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             notifyListeners(type);
         }
 
+        @Override
         public void handleException(Exception exception) {
             try {
                 if (null != target) {
@@ -456,6 +465,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             logger.error("Script compilation exception: {}", source.getName().getName(), exception);
         }
 
+        @Override
         public void setClassLoader(ClassLoader classLoader) {
             this.scriptClassLoader = classLoader;
         }
@@ -494,6 +504,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             return Thread.currentThread().getContextClassLoader();
         }
 
+        @Override
         public Object invoke(Object proxy, Method method, Object[] arguments) throws Throwable {
             // do not proxy equals, hashCode, toString
             if (method.getDeclaringClass() == Object.class) {
@@ -522,14 +533,17 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
                 this.targetProxy = target;
             }
 
+            @Override
             public void addScriptListener(ScriptListener o) {
                 LibraryRecord.this.addScriptListener(o);
             }
 
+            @Override
             public void deleteScriptListener(ScriptListener o) {
                 LibraryRecord.this.deleteScriptListener(o);
             }
 
+            @Override
             public Bindings getScriptBindings(Context context, Bindings request) {
                 if (null == context) {
                     throw new NullPointerException();
@@ -542,6 +556,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
                         ScriptRegistryImpl.this.globalScope.get());
             }
 
+            @Override
             public Script getScript(final Context context) {
                 if (null == context) {
                     throw new NullPointerException();
@@ -561,30 +576,36 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
                     // return engine;
                     // }
 
+                    @Override
                     protected Bindings getGlobalBindings() {
                         return ScriptRegistryImpl.this.globalScope.get();
                     }
 
+                    @Override
                     protected Bindings getServiceBindings() {
                         return ServiceScript.this.getBindings();
                     }
                 };
             }
 
+            @Override
             public ScriptName getName() {
                 return scriptName;
             }
 
+            @Override
             public Visibility getVisibility() {
                 return null != source ? source.getVisibility() : Visibility.DEFAULT;
             }
 
+            @Override
             public boolean isActive() {
                 return target != null;
             }
         }
     }
 
+    @Override
     public void addScriptListener(ScriptName name, ScriptListener hook) {
         if (null != hook && null != name) {
             LibraryRecord record = cache.get(name);
@@ -599,6 +620,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         }
     }
 
+    @Override
     public void deleteScriptListener(ScriptName name, ScriptListener hook) {
         if (null != hook && null != name) {
             LibraryRecord record = cache.get(name);
@@ -628,6 +650,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
     }
 
     // ScriptEngineFactoryObserver
+    @Override
     public void addingEntries(ScriptEngineFactory factory) throws ScriptException {
         engineFactories.add(factory);
         for (LibraryRecord cacheRecord : cache.values()) {
@@ -640,6 +663,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         }
     }
 
+    @Override
     public void removingEntries(ScriptEngineFactory factory) throws ScriptException {
         engineFactories.remove(factory);
         engines.remove(factory);
@@ -654,6 +678,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
     }
 
     // SourceUnitObserver
+    @Override
     public void addSourceUnit(SourceUnit unit) throws ScriptException {
         try {
             if (unit instanceof ScriptSource) {
@@ -695,6 +720,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
         }
     }
 
+    @Override
     public void removeSourceUnit(SourceUnit unit) throws ScriptException {
         if (unit instanceof ScriptSource) {
             LibraryRecord cacheRecord = cache.get(unit.getName());
@@ -730,6 +756,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             this.context = new ScriptContext(context, scriptName.getName(), scriptName.getType(), scriptName.getRevision());
         }
 
+        @Override
         public void putSafe(String key, Object value) {
             if (null == safeBinding) {
                 safeBinding = new SimpleBindings();
@@ -737,6 +764,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             safeBinding.put(key, value);
         }
 
+        @Override
         public Object eval(final Bindings bindings) throws ScriptException {
             try {
                 return target.eval(context, bindings, safeBinding, getServiceBindings(),
@@ -749,6 +777,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             }
         }
 
+        @Override
         public Object eval() throws ScriptException {
             return eval(getBindings());
         }
@@ -763,6 +792,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
 
         private Bindings bindings = null;
 
+        @Override
         public void put(String key, Object value) {
             if (null == bindings) {
                 bindings = createBindings();
@@ -770,6 +800,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             bindings.put(key, value);
         }
 
+        @Override
         public Object get(String key) {
             if (getBindings() != null) {
                 return getBindings().get(key);
@@ -777,18 +808,22 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             return null;
         }
 
+        @Override
         public Bindings getBindings() {
             return bindings;
         }
 
+        @Override
         public void setBindings(Bindings bindings) {
             this.bindings = bindings;
         }
 
+        @Override
         public Bindings createBindings() {
             return new SimpleBindings();
         }
 
+        @Override
         public void flush() {
             setBindings(null);
         }

--- a/script/common/src/main/java/org/forgerock/script/registry/ThreadClassLoaderManager.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ThreadClassLoaderManager.java
@@ -37,6 +37,7 @@ public final class ThreadClassLoaderManager {
 
     private static ThreadLocal<ThreadClassLoaderManager> instance =
             new ThreadLocal<ThreadClassLoaderManager>() {
+                @Override
                 public ThreadClassLoaderManager initialValue() {
                     return new ThreadClassLoaderManager();
                 }

--- a/script/common/src/main/java/org/forgerock/script/scope/OperationParameter.java
+++ b/script/common/src/main/java/org/forgerock/script/scope/OperationParameter.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.scope;
@@ -49,6 +50,7 @@ public class OperationParameter implements Parameter {
      *             If the connection could not be obtained for some other reason
      *             (e.g. due to a configuration or initialization problem).
      */
+    @Override
     public Context getContext(Context savedContext) throws ResourceException {
 
         if (null != savedContext) {

--- a/script/common/src/main/java/org/forgerock/script/source/BundleContainer.java
+++ b/script/common/src/main/java/org/forgerock/script/source/BundleContainer.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.source;
@@ -52,6 +53,7 @@ public class BundleContainer implements SourceContainer {
         this.sourceURI = source.toURI();
     }
 
+    @Override
     public ScriptSource findScriptSource(ScriptName name) {
         URL source = bundle.getResource(name.getName());
         if (source != null) {
@@ -67,22 +69,27 @@ public class BundleContainer implements SourceContainer {
         return null;
     }
 
+    @Override
     public ScriptName getName() {
         return unitName;
     }
 
+    @Override
     public URL getSource() {
         return source;
     }
 
+    @Override
     public URI getSourceURI() {
         return sourceURI;
     }
 
+    @Override
     public ScriptEntry.Visibility getVisibility() {
         return visibility;
     }
 
+    @Override
     public SourceContainer getParentContainer() {
         return null;
     }

--- a/script/common/src/main/java/org/forgerock/script/source/DirectoryContainer.java
+++ b/script/common/src/main/java/org/forgerock/script/source/DirectoryContainer.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.source;
@@ -65,6 +66,7 @@ public class DirectoryContainer implements SourceContainer, ScriptEngineFactoryA
         this.contextURI = context.toURI();
     }
 
+    @Override
     public ScriptSource findScriptSource(ScriptName name) {
         URL sourceURL = getSourceFile(name.getName(), null);
         if (null == sourceURL) {
@@ -88,16 +90,19 @@ public class DirectoryContainer implements SourceContainer, ScriptEngineFactoryA
         return null;
     }
 
+    @Override
     public ScriptName getName() {
         return unitName;
     }
 
+    @Override
     public ScriptEntry.Visibility getVisibility() {
         return visibility;
     }
 
     private URL getSourceFile(final String name, final String extension) {
         return AccessController.doPrivileged(new PrivilegedAction<URL>() {
+            @Override
             public URL run() {
                 try {
                     String filename =
@@ -184,6 +189,7 @@ public class DirectoryContainer implements SourceContainer, ScriptEngineFactoryA
         return decodedFile;
     }
 
+    @Override
     public void setScriptEngineFactory(final Iterable<ScriptEngineFactory> factory) {
         this.factories = factory;
     }
@@ -203,14 +209,17 @@ public class DirectoryContainer implements SourceContainer, ScriptEngineFactoryA
         return roots;
     }
 
+    @Override
     public URL getSource() {
         return context;
     }
 
+    @Override
     public URI getSourceURI() {
         return contextURI;
     }
 
+    @Override
     public SourceContainer getParentContainer() {
         return null;
     }

--- a/script/common/src/main/java/org/forgerock/script/source/EmbeddedScriptSource.java
+++ b/script/common/src/main/java/org/forgerock/script/source/EmbeddedScriptSource.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.source;
@@ -57,36 +58,44 @@ public class EmbeddedScriptSource implements ScriptSource {
                 scriptName.getName(), scriptName.getType(), scriptName.getRevision(), scriptName.getRequestBinding());
     }
 
+    @Override
     public String guessType() {
         return scriptName.getType();
     }
 
+    @Override
     public URL getSource() {
         // TODO Cache the source and get that URL. The cache should be centralised.
         return null;
     }
 
+    @Override
     public URI getSourceURI() {
         // TODO Cache the source and get that URL. The cache should be centralised.
         return null;
     }
 
+    @Override
     public Reader getReader() throws IOException {
         return new StringReader(source);
     }
 
+    @Override
     public ScriptName getName() {
         return scriptName;
     }
 
+    @Override
     public ScriptEntry.Visibility getVisibility() {
         return visibility;
     }
 
+    @Override
     public ScriptName[] getDependencies() {
         return new ScriptName[0];
     }
 
+    @Override
     public SourceContainer getParentContainer() {
         return null;
     }

--- a/script/common/src/main/java/org/forgerock/script/source/URLScriptSource.java
+++ b/script/common/src/main/java/org/forgerock/script/source/URLScriptSource.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.source;
@@ -80,26 +81,32 @@ public class URLScriptSource implements ScriptSource {
         this.parent = parent;
     }
 
+    @Override
     public String guessType() {
         return getName().getType();
     }
 
+    @Override
     public ScriptName getName() {
         return scriptName;
     }
 
+    @Override
     public URL getSource() {
         return source;
     }
 
+    @Override
     public URI getSourceURI() {
         return sourceURI;
     }
 
+    @Override
     public Reader getReader() throws IOException {
         // TODO Do we need the doPrivileged read?
         try {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<Reader>() {
+                @Override
                 public Reader run() throws Exception {
                     return new BufferedReader(new InputStreamReader(getSource().openStream()));
                 }
@@ -109,14 +116,17 @@ public class URLScriptSource implements ScriptSource {
         }
     }
 
+    @Override
     public ScriptEntry.Visibility getVisibility() {
         return null != parent ? parent.getVisibility() : visibility;
     }
 
+    @Override
     public ScriptName[] getDependencies() {
         return null != parent ? new ScriptName[] { parent.getName() } : new ScriptName[0];
     }
 
+    @Override
     public SourceContainer getParentContainer() {
         return parent;
     }

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScript.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScript.java
@@ -105,12 +105,14 @@ public class GroovyScript implements CompiledScript {
         engine.createScript(scriptName, new Binding());
     }
 
+    @Override
     public Bindings prepareBindings(final Context context, final Bindings request,
             final Bindings... scopes) {
         final Map<String, Object> b = mergeBindings(context, request, scopes);
         return b instanceof Bindings ? (Bindings) b : new SimpleBindings(b);
     }
 
+    @Override
     public Object eval(final Context context, final Bindings request, final Bindings... scopes)
             throws ScriptException {
 
@@ -308,18 +310,22 @@ public class GroovyScript implements CompiledScript {
             this.parameter = parameter;
         }
 
+        @Override
         protected Factory<List<Object>> newListFactory(final List<Object> source) {
             return new InnerListFactory(source, parameter);
         }
 
+        @Override
         protected Factory<Map<String, Object>> newMapFactory(final Map<String, Object> source) {
             return new InnerMapFactory(source, parameter);
         }
 
+        @Override
         protected Object convertFunction(final Function<?> source) {
             return new FunctionClosure(null, parameter, source);
         }
 
+        @Override
         public Parameter getParameter() {
             return parameter;
         }
@@ -334,18 +340,22 @@ public class GroovyScript implements CompiledScript {
             this.parameter = parameter;
         }
 
+        @Override
         protected Factory<List<Object>> newListFactory(final List<Object> source) {
             return new InnerListFactory(source, parameter);
         }
 
+        @Override
         protected Factory<Map<String, Object>> newMapFactory(final Map<String, Object> source) {
             return new InnerMapFactory(source, parameter);
         }
 
+        @Override
         protected Object convertFunction(final Function<?> source) {
             return new FunctionClosure(null, parameter, source);
         }
 
+        @Override
         public Parameter getParameter() {
             return parameter;
         }

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineFactory.java
@@ -66,34 +66,42 @@ public class GroovyScriptEngineFactory implements ScriptEngineFactory {
         extensions = Collections.unmodifiableList(extensions);
     }
 
+    @Override
     public String getEngineName() {
         return "Groovy Scripting Engine";
     }
 
+    @Override
     public String getEngineVersion() {
         return "2.0";
     }
 
+    @Override
     public List<String> getExtensions() {
         return extensions;
     }
 
+    @Override
     public List<String> getMimeTypes() {
         return mimeTypes;
     }
 
+    @Override
     public List<String> getNames() {
         return names;
     }
 
+    @Override
     public String getLanguageName() {
         return LANGUAGE_NAME;
     }
 
+    @Override
     public String getLanguageVersion() {
         return GroovySystem.getVersion();
     }
 
+    @Override
     public ScriptEngine getScriptEngine(Map<String, Object> configuration, Collection<SourceContainer> sourceContainers,
             ClassLoader registryLevelClassLoader) {
         if (null == engine) {

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineImpl.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScriptEngineImpl.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.groovy;
@@ -175,6 +176,7 @@ public class GroovyScriptEngineImpl extends AbstractScriptEngine {
         return ic;
     }
 
+    @Override
     public void compileScript(CompilationHandler handler) throws ScriptException {
         try {
             handler.setClassLoader(groovyScriptEngine.getGroovyClassLoader());
@@ -212,6 +214,7 @@ public class GroovyScriptEngineImpl extends AbstractScriptEngine {
         }
     }
 
+    @Override
     public ScriptEngineFactory getFactory() {
         return factory;
     }
@@ -233,6 +236,7 @@ public class GroovyScriptEngineImpl extends AbstractScriptEngine {
         return Script.class.getClassLoader();
     }
 
+    @Override
     public Bindings compileBindings(Context context, Bindings request, Bindings... value) {
         return null;
     }

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/internal/Activator.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/internal/Activator.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.groovy.internal;
@@ -53,6 +54,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
     private static final ConcurrentMap<Bundle, ScriptEngineFactory> REGISTRY =
             new ConcurrentHashMap<Bundle, ScriptEngineFactory>();
 
+    @Override
     public void start(BundleContext context) throws Exception {
         Dictionary<String, Object> properties = new Hashtable<String, Object>(2);
 
@@ -65,6 +67,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
 
     }
 
+    @Override
     public void stop(BundleContext context) throws Exception {
         if (null != serviceRegistration) {
             serviceRegistration.unregister();
@@ -72,6 +75,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
         }
     }
 
+    @Override
     public ScriptEngineFactory getService(Bundle bundle,
             ServiceRegistration<ScriptEngineFactory> registration) {
         ScriptEngineFactory factory = new GroovyScriptEngineFactory();
@@ -82,6 +86,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
         return result;
     }
 
+    @Override
     public void ungetService(Bundle bundle, ServiceRegistration<ScriptEngineFactory> registration,
             ScriptEngineFactory service) {
         REGISTRY.remove(bundle);

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/AbstractScriptableRequest.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/AbstractScriptableRequest.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -146,6 +147,7 @@ abstract class AbstractScriptableRequest extends NativeObject implements Wrapper
         return request;
     }
 
+    @Override
     public String toString() {
         if (request == null) {
             return "null";

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/Converter.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/Converter.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -301,18 +302,22 @@ class Converter {
             this.parameter = parameter;
         }
 
+        @Override
         public Parameter getParameter() {
             return parameter;
         }
 
+        @Override
         protected Factory<List<Object>> newListFactory(final List<Object> source) {
             return Converter.getList(parameter, source);
         }
 
+        @Override
         protected Factory<Map<String, Object>> newMapFactory(final Map<String, Object> source) {
             return Converter.getMap(parameter, source);
         }
 
+        @Override
         protected Object convertFunction(final Function<?> source) {
             return source;
         }
@@ -327,18 +332,22 @@ class Converter {
             this.parameter = parameter;
         }
 
+        @Override
         public Parameter getParameter() {
             return parameter;
         }
 
+        @Override
         protected Factory<List<Object>> newListFactory(final List<Object> source) {
             return Converter.getList(parameter, source);
         }
 
+        @Override
         protected Factory<Map<String, Object>> newMapFactory(final Map<String, Object> source) {
             return Converter.getMap(parameter, source);
         }
 
+        @Override
         protected Object convertFunction(final Function<?> source) {
             return source;
         }

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
@@ -107,6 +107,7 @@ public class RhinoScript implements CompiledScript {
      * Proxy class to avoid proliferation of anonymous classes.
      */
     private static class IProxy implements QuitAction {
+        @Override
         public void quit(Context cx, int exitCode) {
             /* no quit :) */
         }
@@ -223,6 +224,7 @@ public class RhinoScript implements CompiledScript {
         return name.indexOf("/") != -1 ? name.substring(name.lastIndexOf("/") + 1) : name;
     }
 
+    @Override
     public Bindings prepareBindings(org.forgerock.services.context.Context context, Bindings request, Bindings... scopes) {
         // TODO Fix it later
         return new SimpleBindings();
@@ -334,6 +336,7 @@ public class RhinoScript implements CompiledScript {
             super(parent);
         }
 
+        @Override
         public Class<?> loadClass(String name) throws ClassNotFoundException {
             // First check whether it's already been loaded, if so use it
             Class loadedClass = Kit.classOrNull(getParent(), name);

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
@@ -213,6 +213,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine {
         throw new ScriptException("Script is not found:" + scriptName);
     }
 
+    @Override
     public void compileScript(CompilationHandler handler) throws ScriptException {
         try {
             boolean sharedScope = true;// config.get("sharedScope").defaultTo(true).asBoolean();
@@ -266,6 +267,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine {
         }
     }
 
+    @Override
     public ScriptEngineFactory getFactory() {
         return factory;
     }

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngineFactory.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngineFactory.java
@@ -21,6 +21,7 @@
 * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 * or visit www.oracle.com if you need additional information or have any
 * questions.
+* Portions Copyrighted 2026 3A Systems, LLC
 */
 
 /*
@@ -79,34 +80,42 @@ public class RhinoScriptEngineFactory implements ScriptEngineFactory {
         extensions = Collections.unmodifiableList(extensions);
     }
 
+    @Override
     public String getEngineName() {
         return "javascript";
     }
 
+    @Override
     public String getEngineVersion() {
         return VERSION;
     }
 
+    @Override
     public List<String> getExtensions() {
         return extensions;
     }
 
+    @Override
     public List<String> getMimeTypes() {
         return mimeTypes;
     }
 
+    @Override
     public List<String> getNames() {
         return names;
     }
 
+    @Override
     public String getLanguageName() {
         return LANGUAGE_NAME;
     }
 
+    @Override
     public String getLanguageVersion() {
         return "1.8";
     }
 
+    @Override
     public ScriptEngine getScriptEngine(
             final Map<String, Object> configuration,
             final Collection<SourceContainer> sourceContainers,

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/SLF4JErrorReporter.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/SLF4JErrorReporter.java
@@ -49,6 +49,7 @@ public class SLF4JErrorReporter implements ErrorReporter {
         this.chainedReporter = chainedReporter;
     }
 
+    @Override
     public void warning(String message, String sourceName, int line, String lineSource,
             int lineOffset) {
         logger.warn("{} ({}#{}): {} [offset {}]", new Object[] { message, sourceName, line, lineSource, lineOffset });
@@ -57,6 +58,7 @@ public class SLF4JErrorReporter implements ErrorReporter {
         }
     }
 
+    @Override
     public void error(String message, String sourceName, int line, String lineSource, int lineOffset) {
         logger.error("{} ({}#{}): {} [offset {}]", new Object[] { message, sourceName, line, lineSource, lineOffset });
         if (chainedReporter != null) {
@@ -66,6 +68,7 @@ public class SLF4JErrorReporter implements ErrorReporter {
         }
     }
 
+    @Override
     public EvaluatorException runtimeError(String message, String sourceName, int line,
             String lineSource, int lineOffset) {
         if (chainedReporter != null) {

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableContext.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableContext.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -216,6 +217,7 @@ class ScriptableContext extends NativeObject implements Wrapper {
         return getWrappedContext();
     }
 
+    @Override
     public String toString() {
         final JsonValue allContexts = new JsonValue(new HashMap<String,Object>(contexts.size()));
         for (final Map.Entry<String,Context> entry : contexts.entrySet()) {

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableMap.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableMap.java
@@ -20,6 +20,7 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -162,6 +163,7 @@ class ScriptableMap extends NativeObject implements Wrapper {
         return map;
     }
 
+    @Override
     public String toString() {
         return map == null ? "null" : new JsonValue(map).toString();
     }

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/internal/Activator.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/internal/Activator.java
@@ -1,3 +1,29 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ *
+ * The contents of this file are subject to the terms
+ * of the Common Development and Distribution License
+ * (the License). You may not use this file except in
+ * compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://forgerock.org/license/CDDLv1.0.html
+ * See the License for the specific language governing
+ * permission and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL
+ * Header Notice in each file and include the License file
+ * at http://forgerock.org/license/CDDLv1.0.html
+ * If applicable, add the following below the CDDL Header,
+ * with the fields enclosed by brackets [] replaced by
+ * your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
+ */
+
 package org.forgerock.script.javascript.internal;
 
 import java.util.Dictionary;
@@ -29,6 +55,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
     private static final ConcurrentMap<Bundle, ScriptEngineFactory> REGISTRY =
             new ConcurrentHashMap<Bundle, ScriptEngineFactory>();
 
+    @Override
     public void start(BundleContext context) throws Exception {
         Dictionary<String, Object> properties = new Hashtable<String, Object>();
 
@@ -41,6 +68,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
 
     }
 
+    @Override
     public void stop(BundleContext context) throws Exception {
         if (null != serviceRegistration) {
             serviceRegistration.unregister();
@@ -48,6 +76,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
         }
     }
 
+    @Override
     public ScriptEngineFactory getService(Bundle bundle,
             ServiceRegistration<ScriptEngineFactory> registration) {
         ScriptEngineFactory factory = new RhinoScriptEngineFactory();
@@ -58,6 +87,7 @@ public class Activator implements BundleActivator, ServiceFactory<ScriptEngineFa
         return result;
     }
 
+    @Override
     public void ungetService(Bundle bundle, ServiceRegistration<ScriptEngineFactory> registration,
             ScriptEngineFactory service) {
         REGISTRY.remove(bundle);


### PR DESCRIPTION
## CodeQL: `java/missing-override-annotation`

Adds the missing `@Override` annotation to **308 methods** across **97 files** in 9 modules. Each annotated method overrides a superclass method or implements an interface method but lacked the annotation.

The change is **annotation-only and behavior-preserving**. Because `@Override` on a non-overriding method is a compile error, correctness is guaranteed by compilation:

- All 39 affected Maven modules compile (`mvn -pl <module> compile`).
- The two `persistit/examples` files (Ant-built, not in the Maven reactor) were verified with `javac` against `persistit-core`.

### Distribution
| module | annotations |
|---|---:|
| commons | 56 files |
| script | 22 files |
| i18n-framework | 6 files |
| maven-external-dependency-plugin | 5 files |
| guice | 3 files |
| persistit (examples) | 2 files |
| cassandra-embedded / build-tools / bloomfilter | 1 each |

Closes the open `java/missing-override-annotation` code-scanning alerts.
