### PR TITLE
Replace boxed-primitive constructors with valueOf (CodeQL java/inefficient-boxed-constructor)

### DIFF
--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -563,7 +563,7 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
      */
     private int getCookieMaxAge(Date now, Date exp) {
         if (!browserSessionOnly) {
-            return new Long((exp.getTime() - now.getTime()) / 1000L).intValue();
+            return Long.valueOf((exp.getTime() - now.getTime()) / 1000L).intValue();
         } else {
             return -1;
         }

--- a/persistit/core/src/main/java/com/persistit/DefaultValueCoder.java
+++ b/persistit/core/src/main/java/com/persistit/DefaultValueCoder.java
@@ -379,7 +379,7 @@ public class DefaultValueCoder implements ValueRenderer, HandleCache {
 
         final char ch = name.charAt(0);
         if (Character.isLetter(ch) && Character.isLowerCase(ch)) {
-            baseName = new Character(Character.toUpperCase(ch)) + name.substring(1);
+            baseName = Character.valueOf(Character.toUpperCase(ch)) + name.substring(1);
         } else {
             baseName = name;
         }

--- a/persistit/core/src/main/java/com/persistit/ManagementImpl.java
+++ b/persistit/core/src/main/java/com/persistit/ManagementImpl.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -345,7 +346,7 @@ class ManagementImpl implements Management {
         final BufferPoolInfo[] result = new BufferPoolInfo[size];
         int index = 0;
         for (int bufferSize = Buffer.MIN_BUFFER_SIZE; bufferSize <= Buffer.MAX_BUFFER_SIZE; bufferSize *= 2) {
-            final BufferPool pool = bufferPoolTable.get(new Integer(bufferSize));
+            final BufferPool pool = bufferPoolTable.get(Integer.valueOf(bufferSize));
 
             if (pool != null && index < size) {
                 final BufferPoolInfo info = new BufferPoolInfo();
@@ -1050,7 +1051,7 @@ class ManagementImpl implements Management {
             final long taskId = ++_taskIdCounter;
             task.setPersistit(_persistit);
             task.setup(taskId, description, owner, maximumTime, verbosity);
-            _tasks.put(new Long(taskId), task);
+            _tasks.put(Long.valueOf(taskId), task);
             task.start();
             return taskId;
         } catch (final Exception ex) {
@@ -1153,7 +1154,7 @@ class ManagementImpl implements Management {
                     task.resume();
             }
         } else {
-            final Task task = _tasks.get(new Long(taskId));
+            final Task task = _tasks.get(Long.valueOf(taskId));
             if (task != null) {
                 if (suspend)
                     task.suspend();
@@ -1185,11 +1186,11 @@ class ManagementImpl implements Management {
                 _tasks.clear();
             }
         } else {
-            final Task task = _tasks.get(new Long(taskId));
+            final Task task = _tasks.get(Long.valueOf(taskId));
             if (task != null) {
                 task.stop();
                 if (remove) {
-                    _tasks.remove(new Long(task._taskId));
+                    _tasks.remove(Long.valueOf(task._taskId));
                 }
             }
         }
@@ -1310,7 +1311,7 @@ class ManagementImpl implements Management {
         try {
             final long taskId = taskId();
             task.setup(taskId, description, Thread.currentThread().getName(), 0, 5);
-            _tasks.put(new Long(taskId), task);
+            _tasks.put(Long.valueOf(taskId), task);
             task.start();
             return Long.toString(taskId);
         } catch (final Exception ex) {

--- a/persistit/core/src/main/java/com/persistit/Persistit.java
+++ b/persistit/core/src/main/java/com/persistit/Persistit.java
@@ -1497,7 +1497,7 @@ public class Persistit {
    * @return the <code>BufferPool</code> for the specific buffer size
    */
   BufferPool getBufferPool(final int size) {
-    return _bufferPoolTable.get(new Integer(size));
+    return _bufferPoolTable.get(Integer.valueOf(size));
   }
 
   /**

--- a/persistit/examples/FindFile/FindFile.java
+++ b/persistit/examples/FindFile/FindFile.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 import java.awt.BorderLayout;
@@ -293,7 +294,7 @@ public class FindFile extends JPanel {
             KeyFilter filter = new KeyFilter(ex.getKey());
             if (fixed.length() != 0) {
                 String end = fixed.substring(0, fixed.length() - 1)
-                        + new Character((char) (fixed.charAt(fixed.length() - 1) + 1));
+                        + Character.valueOf((char) (fixed.charAt(fixed.length() - 1) + 1));
                 //
                 // append a Term that selects only the range accepted by the
                 // fixed portion of the name.

--- a/persistit/ui/src/main/java/com/persistit/ui/ValueInspectorTreeNode.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/ValueInspectorTreeNode.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit.ui;
@@ -378,19 +379,19 @@ class ValueInspectorTreeNode implements TreeNode {
             if (elementType == boolean.class) {
                 element = ((boolean[]) _object)[index] ? Boolean.TRUE : Boolean.FALSE;
             } else if (elementType == byte.class) {
-                element = new Byte(((byte[]) _object)[index]);
+                element = Byte.valueOf(((byte[]) _object)[index]);
             } else if (elementType == short.class) {
-                element = new Short(((short[]) _object)[index]);
+                element = Short.valueOf(((short[]) _object)[index]);
             } else if (elementType == char.class) {
-                element = new Character(((char[]) _object)[index]);
+                element = Character.valueOf(((char[]) _object)[index]);
             } else if (elementType == int.class) {
-                element = new Integer(((int[]) _object)[index]);
+                element = Integer.valueOf(((int[]) _object)[index]);
             } else if (elementType == long.class) {
-                element = new Long(((long[]) _object)[index]);
+                element = Long.valueOf(((long[]) _object)[index]);
             } else if (elementType == float.class) {
-                element = new Float(((float[]) _object)[index]);
+                element = Float.valueOf(((float[]) _object)[index]);
             } else if (elementType == double.class) {
-                element = new Double(((double[]) _object)[index]);
+                element = Double.valueOf(((double[]) _object)[index]);
             } else
                 throw new RuntimeException();
         } else {


### PR DESCRIPTION
## Summary

Resolves the CodeQL **`java/inefficient-boxed-constructor`** alerts (17 open) by replacing deprecated boxed-primitive constructors with the corresponding `valueOf(...)` factory methods.

`new Integer(x)` / `new Long(x)` / … always allocate a fresh object and have been deprecated since Java 9. `X.valueOf(x)` is the recommended form: it avoids the redundant allocation and may reuse cached instances. The change is **behavior-preserving** — equal values with identical `equals`/`hashCode`; none of the touched sites rely on reference identity (`==`).

## Changes (17 replacements across 6 files)

| File | Module | Replacements |
|------|--------|-------------|
| `AbstractJwtSessionModule.java` | commons/auth-filters (jwt-session-module) | 1× `Long` |
| `DefaultValueCoder.java` | persistit/core | 1× `Character` |
| `ManagementImpl.java` | persistit/core | 1× `Integer`, 5× `Long` |
| `Persistit.java` | persistit/core | 1× `Integer` |
| `FindFile.java` | persistit/examples | 1× `Character` |
| `ValueInspectorTreeNode.java` | persistit/ui | `Byte`, `Short`, `Character`, `Integer`, `Long`, `Float`, `Double` |

## Verification

- Compiled `persistit/core`, `persistit/ui` and the jaspi `jwt-session-module` (all clean).
- `javac` for the `FindFile` persistit Ant example (not part of the Maven reactor).

Annotation of the fix is purely local (`new X(` → `X.valueOf(`); arguments and surrounding expressions are unchanged.
