### PR TITLE
Fix stale Javadoc @param/@throws tags (CodeQL unknown-javadoc-parameter, inconsistent-javadoc-throws)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/AccumulatorState.java
+++ b/persistit/core/src/main/java/com/persistit/AccumulatorState.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -32,10 +33,6 @@ final class AccumulatorState {
      * Deserialize stored statistics values from the supplied byte array
      * starting at <code>index</code>.
      * 
-     * @param bytes
-     *            serialized statistics
-     * @param index
-     *            at which serialized statistics start in the byte array
      */
     void load(final Value value) {
         _treeName = value.getString();

--- a/persistit/core/src/main/java/com/persistit/AlertMonitor.java
+++ b/persistit/core/src/main/java/com/persistit/AlertMonitor.java
@@ -283,8 +283,6 @@ public final class AlertMonitor extends NotificationBroadcasterSupport implement
          * 
          * @param event
          *            the <code>Event</code> to add
-         * @param level
-         *            the <code>AlertLevel</code> that should be assigned to it
          */
         private void addEvent(final Event event) {
             trim(_historyLength - 1);

--- a/persistit/core/src/main/java/com/persistit/Buffer.java
+++ b/persistit/core/src/main/java/com/persistit/Buffer.java
@@ -1395,7 +1395,7 @@ public class Buffer extends SharedResource {
      *
      * @param key
      *            The key on under which the value will be stored
-     * @param value
+     * @param valueHelper
      *            The value, converted to a byte array
      * @throws PersistitInterruptedException
      */
@@ -1411,7 +1411,7 @@ public class Buffer extends SharedResource {
      *
      * @param key
      *            The key under which the value will be stored
-     * @param value
+     * @param valueHelper
      *            The value to be stored
      * @param foundAt
      *            The keyblock before which this record will be inserted
@@ -1894,7 +1894,7 @@ public class Buffer extends SharedResource {
      *            The buffer containing the new right sibling page
      * @param key
      *            The key being inserted or replaced
-     * @param value
+     * @param valueHelper
      *            The new value
      * @param foundAt
      *            Offset to keyblock where insertion will occur
@@ -2769,11 +2769,6 @@ public class Buffer extends SharedResource {
      * @param adjustmentForNewEbc
      *            amount by which the tail block of the record at foundAt2 must
      *            increase to allow for a reduced ebc value
-     * @param indexKey
-     *            Key in which the newly elected edge key will be returned
-     * @param spareKey
-     *            A spare Key in which intermediate key values can be
-     *            accumulated
      * @param policy
      *            JoinPolicy used to choose optimal rebalance point
      * @return the join offset as described above
@@ -3590,7 +3585,6 @@ public class Buffer extends SharedResource {
      * new checkpoint has been proposed.
      *
      * @param tree
-     * @param spareKey
      * @return <code>true</code> if this method changed the contents of the
      *         buffer
      * @throws PersistitException

--- a/persistit/core/src/main/java/com/persistit/ClassIndex.java
+++ b/persistit/core/src/main/java/com/persistit/ClassIndex.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -95,7 +96,6 @@ final class ClassIndex {
      * 
      * @param persistit
      *            Owning Persistit instance.
-     * @throws PersistitException
      */
     ClassIndex(final Persistit persistit) {
         _persistit = persistit;

--- a/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
+++ b/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
@@ -757,8 +757,6 @@ public class IntegrityCheck extends Task {
     /**
      * Resets this <code>IntegrityCheck</code> to handle a new volume.
      * 
-     * @param initCounts
-     *            <code>true</code> to reset all counters to zero.
      */
     private void reset() {
         _currentVolume = null;
@@ -891,7 +889,6 @@ public class IntegrityCheck extends Task {
      * 
      * @param page
      * @param level
-     * @param work
      * @throws PersistitException
      */
     private void checkTree(final Key parentKey, final long parent, final long page, final int level, final Tree tree)

--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -850,8 +851,6 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
      *
      * @param address
      *            journal address
-     * @param _bb
-     *            ByteBuffer in which to return the result
      * @return pageAddress of the page at the specified location, or -1 if the
      *         address does not reference a valid page
      * @throws PersistitException
@@ -1623,7 +1622,7 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
      * @param address
      *            the journal address of a record in the journal for which the
      *            corresponding channel will be returned
-     * @throws PersistitException
+     * @throws PersistitIOException
      *             if the <code>MediatedFileChannel</code> cannot be created
      */
     synchronized FileChannel getFileChannel(final long address) throws PersistitIOException {
@@ -2980,7 +2979,7 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
     /**
      * For use only by unit tests that test page maps, etc.
      *
-     * @param handleToVolumeMap
+     * @param pageMap
      */
     void unitTestInjectPageMap(final Map<PageNode, PageNode> pageMap) {
         _pageMap.putAll(pageMap);

--- a/persistit/core/src/main/java/com/persistit/Key.java
+++ b/persistit/core/src/main/java/com/persistit/Key.java
@@ -1820,8 +1820,6 @@ public final class Key implements Comparable<Object> {
      * Encodes an int into a supplied byte array.
      * 
      * @param v
-     * @param bytes
-     * @param offset
      * @return size of appended segment
      */
     private int appendIntInternal(final int v) {

--- a/persistit/core/src/main/java/com/persistit/MVV.java
+++ b/persistit/core/src/main/java/com/persistit/MVV.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -790,8 +791,6 @@ class MVV {
      * Internal helper. Used to assert a given byte array is large enough before
      * writing.
      * 
-     * @param target
-     *            Array to check
      * @param length
      *            Length needed
      * @throws IllegalArgumentException

--- a/persistit/core/src/main/java/com/persistit/ManagementImpl.java
+++ b/persistit/core/src/main/java/com/persistit/ManagementImpl.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -190,7 +191,7 @@ class ManagementImpl implements Management {
      * requested it to close so that the final state of the Persistit
      * environment can be examined.
      * 
-     * @param enabled
+     * @param suspended
      *            <code>true</code> to specify that Persistit will wait when
      *            attempting to close; otherwise <code>false</code>.
      */
@@ -206,7 +207,6 @@ class ManagementImpl implements Management {
      * 
      * @return <code>true</code> if Persistit will suspend any attempt to update
      *         a <code>Volume</code>; otherwise <code>false</code>.
-     * @throws RemoteException
      */
     @Override
     public boolean isUpdateSuspended() {
@@ -219,7 +219,6 @@ class ManagementImpl implements Management {
      * update operation indefinitely.
      * 
      * @param suspended
-     * @throws RemoteException
      */
     @Override
     public void setUpdateSuspended(final boolean suspended) {
@@ -1025,11 +1024,6 @@ class ManagementImpl implements Management {
      *            Readable description of this task
      * @param owner
      *            Hostname or username of the user who requested this task
-     * @param className
-     *            Class name of task to run, e.g.,
-     *            <code>com.persistit.IntegrityCheck</code>.
-     * @param args
-     *            Task-specific parameters
      * @param maximumTime
      *            Maximum wall-clock time (in milliseconds) this Task will be
      *            allowed to run, or 0 for unbounded time
@@ -1072,7 +1066,6 @@ class ManagementImpl implements Management {
      * @param clearMessages
      *            <code>true</code> to clear all received messages from the
      *            task.
-     * @throws RemoteException
      */
     @Override
     public synchronized TaskStatus[] queryTaskStatus(final long taskId, final boolean details,
@@ -1097,7 +1090,6 @@ class ManagementImpl implements Management {
      * @param clearTasks
      *            <code>true</code> to remove the task's status if it has
      *            finished, failed or expired.
-     * @throws RemoteException
      */
     @Override
     public synchronized TaskStatus[] queryTaskStatus(final long taskId, final boolean details,
@@ -1140,7 +1132,6 @@ class ManagementImpl implements Management {
      * @param suspend
      *            <code>true</code> to suspend the task, <code>false</code> to
      *            allow it to resume.
-     * @throws RemoteException
      */
     @Override
     public synchronized void setTaskSuspended(final long taskId, final boolean suspend) {
@@ -1172,7 +1163,6 @@ class ManagementImpl implements Management {
      * 
      * @param taskId
      *            Task ID for a selected Task.
-     * @throws RemoteException
      */
     @Override
     public synchronized void stopTask(final long taskId, final boolean remove) {
@@ -1202,7 +1192,6 @@ class ManagementImpl implements Management {
      * @param taskId
      *            Task ID for a selected task, or -1 for all tasks.
      * 
-     * @throws RemoteException
      */
     @Override
     public synchronized void removeFinishedTasks(final long taskId) {

--- a/persistit/core/src/main/java/com/persistit/RecoveryManager.java
+++ b/persistit/core/src/main/java/com/persistit/RecoveryManager.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -684,7 +685,7 @@ public class RecoveryManager implements RecoveryManagerMXBean, VolumeHandleLooku
     }
 
     /**
-     * @param recoverDisabledForTestMode
+     * @param recoveryDisabledForTestMode
      *            Set this to <code>true</code> to disable the
      *            {@link #applyAllCommittedTransactions()} method. (Lets unit
      *            tests look at the plan before executing it.)
@@ -917,7 +918,7 @@ public class RecoveryManager implements RecoveryManagerMXBean, VolumeHandleLooku
      *         {@link com.persistit.JournalRecord}), 0 if the journal file has
      *         fewer than 16 bytes remaining or -t where t is an invalid type.
      * @throws CorruptJournalException
-     * @throws PersistitException
+     * @throws PersistitIOException
      * @throws JournalNotClosedException
      */
     private int scanOneRecord() throws PersistitIOException {
@@ -1434,7 +1435,6 @@ public class RecoveryManager implements RecoveryManagerMXBean, VolumeHandleLooku
      * Called during Phase 2 to record the FileAddress of a Transaction Update
      * record in the journal.
      * 
-     * @param ja
      * @throws CorruptJournalException
      */
     void scanOneTransaction(final long address, final long startTimestamp, final int recordSize)
@@ -1567,8 +1567,6 @@ public class RecoveryManager implements RecoveryManagerMXBean, VolumeHandleLooku
      *            displaying error messages
      * @param timestamp
      *            timestamp of the transaction
-     * @param page
-     * 
      * @throws PersistitException
      */
     void convertToLongRecord(final Value value, final int treeHandle, final long from, final long timestamp)

--- a/persistit/core/src/main/java/com/persistit/SharedResource.java
+++ b/persistit/core/src/main/java/com/persistit/SharedResource.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -411,7 +412,7 @@ abstract class SharedResource {
      * Sets bits in the state. This method does not change the bits used by the
      * synchronizer to maintain lock state.
      * 
-     * @param mask
+     * @param resource
      */
     void setStatus(final SharedResource resource) {
         final int mask = resource.getStatus();

--- a/persistit/core/src/main/java/com/persistit/TimelyResource.java
+++ b/persistit/core/src/main/java/com/persistit/TimelyResource.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -315,7 +316,7 @@ public class TimelyResource<V extends Version> {
      * 
      * @param entry
      * @param txn
-     * @throws PersistitException
+     * @throws PersistitInterruptedException
      * @throws RollbackException
      */
     private void addVersion(final Entry entry, final Transaction txn) throws PersistitInterruptedException,

--- a/persistit/core/src/main/java/com/persistit/TransactionIndex.java
+++ b/persistit/core/src/main/java/com/persistit/TransactionIndex.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -950,7 +951,7 @@ class TransactionIndex implements TransactionIndexMXBean {
      * bucket. This method is called during recovery processing to register
      * transactions that were
      * 
-     * @param timestamp
+     * @param ts
      * @throws InterruptedException
      */
     void injectAbortedTransaction(final long ts) throws InterruptedException {

--- a/persistit/core/src/main/java/com/persistit/TransactionStatus.java
+++ b/persistit/core/src/main/java/com/persistit/TransactionStatus.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -174,7 +175,7 @@ class TransactionStatus {
     /**
      * Link another TransactionStatus this one depends on.
      * 
-     * @param next
+     * @param depends
      *            the TransactionStatus to link
      */
     void setDepends(final TransactionStatus depends) {

--- a/persistit/core/src/main/java/com/persistit/Tree.java
+++ b/persistit/core/src/main/java/com/persistit/Tree.java
@@ -285,7 +285,6 @@ public class Tree extends SharedResource {
     /**
      * Save a Tree in the directory
      * 
-     * @param value
      */
     int store(final byte[] bytes, final int index) {
         final byte[] nameBytes = Util.stringToBytes(_name);
@@ -301,7 +300,6 @@ public class Tree extends SharedResource {
     /**
      * Load an existing Tree from the directory
      * 
-     * @param value
      */
     int load(final byte[] bytes, final int index, final int length) {
         final int nameLength = length < 20 ? -1 : Util.getShort(bytes, index + 18);

--- a/persistit/core/src/main/java/com/persistit/TreeState.java
+++ b/persistit/core/src/main/java/com/persistit/TreeState.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -66,7 +67,6 @@ public class TreeState {
      * {@link Tree#store(byte[], int)} operation. This class is only for display
      * and reference.
      * 
-     * @param value
      */
     int load(final byte[] bytes, final int index, final int length) {
         final int nameLength = length < 20 ? -1 : Util.getShort(bytes, index + 18);

--- a/persistit/core/src/main/java/com/persistit/Version.java
+++ b/persistit/core/src/main/java/com/persistit/Version.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -60,7 +61,6 @@ interface Version {
      * 
      * @author peter
      * 
-     * @param <T>
      * @param <V>
      */
     interface VersionCreator<V> {

--- a/persistit/core/src/main/java/com/persistit/Volume.java
+++ b/persistit/core/src/main/java/com/persistit/Volume.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -406,7 +407,7 @@ public class Volume {
      * Return a TreeInfo structure for a tree by the specified name. If there is
      * no such tree, then return <code>null</code>.
      * 
-     * @param tree
+     * @param name
      *            name
      * @return an information structure for the Management interface.
      */

--- a/persistit/core/src/main/java/com/persistit/VolumeHeader.java
+++ b/persistit/core/src/main/java/com/persistit/VolumeHeader.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -292,8 +293,6 @@ class VolumeHeader {
      * 
      * @return <code>true</code> if and only if there already exists a Volume
      *         file.
-     * @throws PersistitException
-     * @throws IOException
      * @throws InvalidVolumeSpecificationException
      * @throws CorruptVolumeException
      * @throws PersistitIOException

--- a/persistit/core/src/main/java/com/persistit/VolumeStructure.java
+++ b/persistit/core/src/main/java/com/persistit/VolumeStructure.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -401,7 +402,7 @@ class VolumeStructure {
      * Return a TreeInfo structure for a tree by the specified name. If there is
      * no such tree, then return <i>null</i>.
      * 
-     * @param tree
+     * @param name
      *            name
      * @return an information structure for the Management interface.
      */

--- a/persistit/doc/build/src/AsciiDocIndex.java
+++ b/persistit/doc/build/src/AsciiDocIndex.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 import java.io.File;
@@ -55,13 +56,10 @@ public class AsciiDocIndex {
      * content of that one file. If it is a directory, read the files in that
      * directory and index them.
      * 
-     * @param file
-     * 
      * @return The count of indexable terms in the file or directory
      * 
      * @throws IOException
      * 
-     * @throws PersistitException
      */
     public int buildIndex(final String pathName, String base) throws IOException {
         File file = new File(pathName);

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
@@ -193,7 +193,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine {
      * @param scriptName
      *            name of the script to run
      * @return the script object
-     * @throws ResourceException
+     * @throws ScriptException
      *             if there is a problem accessing the script
      */
     Script createScript(String scriptName) throws ScriptException {


### PR DESCRIPTION
## Summary

Resolves all open CodeQL alerts for **`java/unknown-javadoc-parameter`** (32) and **`java/inconsistent-javadoc-throws`** (15) — 47 stale Javadoc tags that reference a parameter or exception the method does not have, across 22 files (mostly `persistit/core`). Documentation-only; no code changes.

Each tag is **corrected where a correct form exists**, and removed only where there is nothing to correct to.

## Renamed (15)

`@param` corrected to the real parameter name:

| From | To | Where |
|------|----|-------|
| `@param value` | `@param valueHelper` | `Buffer.putValue` (×2), `Buffer.split` |
| `@param enabled` | `@param suspended` | `ManagementImpl.setShutdownSuspended` |
| `@param mask` | `@param resource` | `SharedResource.setStatus` |
| `@param recoverDisabledForTestMode` | `@param recoveryDisabledForTestMode` | `RecoveryManager` (typo) |
| `@param timestamp` | `@param ts` | `TransactionIndex.injectAbortedTransaction` |
| `@param next` | `@param depends` | `TransactionStatus.setDepends` |
| `@param tree` | `@param name` | `Volume` / `VolumeStructure.getTreeInfo` |
| `@param handleToVolumeMap` | `@param pageMap` | `JournalManager.unitTestInjectPageMap` |

`@throws` corrected to the exception actually declared:

| From | To | Where |
|------|----|-------|
| `@throws PersistitException` | `@throws PersistitIOException` | `JournalManager.getFileChannel`, `RecoveryManager.scanOneRecord` |
| `@throws PersistitException` | `@throws PersistitInterruptedException` | `TimelyResource.addVersion` |
| `@throws ResourceException` | `@throws ScriptException` | `RhinoScriptEngine.createScript` |

## Removed (32)

Removed where no correct form applies:
- Leftovers from old signatures (e.g. `byte[] bytes` / `int index` parameters replaced by a single `Value value`): `AccumulatorState`, `Key.appendIntInternal`, `Tree` / `TreeState`.
- Spurious `@param` tags with no matching parameter: `level`, `_bb`, `spareKey`, `indexKey`, `work`, `target`, `ja`, `page`, `className`, `args`, `file`, and a stray `@param <T>` type parameter.
- RMI `@throws RemoteException` on `ManagementImpl` methods that no longer declare it (×7), and `@throws PersistitException` on a constructor / `buildIndex` that throw no Persistit exception.
- `VolumeHeader.verifyVolumeHeader`: `@throws PersistitException` / `@throws IOException` removed because the precise `@throws CorruptVolumeException` / `@throws PersistitIOException` were already present in the same block.

## Verification
Compiled `persistit/core` and `script/javascript`, and ran `javadoc:javadoc` (doclint, enabled repo-wide) on `persistit/core` — all clean, confirming every renamed reference resolves.
