### PR TITLE
Add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ 'sustaining/2.4.x','master', 'issues/**', 'features/**' ]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
 # Cancel superseded runs on the same ref to avoid the long-running,
 # eventually-cancelled analyses seen with the previous default setup.
 concurrency:
-  group: codeql-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [ 'sustaining/2.4.x','master' ]
     workflows: ["Build Maven","Release Maven"]
     types: [completed]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 jobs:
   deploy:
     name: Maven deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         description: "Default version to use for new local working copy."
         required: true
         default: "X.Y.Z-SNAPSHOT"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Maven release


### PR DESCRIPTION
## Summary

Adds a `concurrency` group to every GitHub Actions workflow so superseded runs on the same ref no longer pile up.

| Workflow | group | cancel-in-progress |
|----------|-------|--------------------|
| build.yml | `${{ github.workflow }}-${{ github.ref }}` | `true` |
| codeql.yml | `${{ github.workflow }}-${{ github.ref }}` | `true` |
| deploy.yml | `${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}` | `false` |
| release.yml | `${{ github.workflow }}-${{ github.ref }}` | `false` |

## Details

- **build / codeql** — `cancel-in-progress: true` drops stale CI/analysis runs when a newer push arrives on the same ref.
- **deploy / release** — `cancel-in-progress: false` so in-flight publishing/release runs are queued rather than aborted mid-way.
- **deploy** — keyed on `github.event.workflow_run.head_branch` because a `workflow_run`-triggered run has no meaningful `github.ref` (it points at the default branch, not the source build's branch).
- **codeql** — aligns the pre-existing `codeql-*` group name with the shared pattern.
