### PR TITLE
Silence doclint "missing" warnings and fix remaining HTML/reference javadoc

### DIFF
--- a/commons/audit/core/src/main/java/org/forgerock/audit/events/AccessAuditEventBuilder.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/events/AccessAuditEventBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.events;
 
@@ -46,14 +47,14 @@ import org.slf4j.LoggerFactory;
  * new specific fields, e.g
  * <pre>
  * <code>
- * class OpenProductAccessAuditEventBuilder{@code <T extends OpenProductAccessAuditEventBuilder<T>>}
- extends AccessAuditEventBuilder{@code <T>} {
+ * class OpenProductAccessAuditEventBuilder&lt;T extends OpenProductAccessAuditEventBuilder&lt;T&gt;&gt;
+ extends AccessAuditEventBuilder&lt;T&gt; {
  *
  *    protected OpenProductAccessAuditEventBuilder(DnsUtils dnsUtils) {
  *        super(dnsUtils);
  *    }
  *
- *    public static {@code <T>} OpenProductAccessAuditEventBuilder{@code <?>} productAccessEvent() {
+ *    public static &lt;T&gt; OpenProductAccessAuditEventBuilder&lt;?&gt; productAccessEvent() {
  *       return new OpenProductAccessAuditEventBuilder(new DnsUtils());
  *    }
  *

--- a/commons/audit/core/src/main/java/org/forgerock/audit/events/ActivityAuditEventBuilder.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/events/ActivityAuditEventBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.events;
 
@@ -22,10 +23,10 @@ package org.forgerock.audit.events;
  * new specific fields, e.g
  * <pre>
  * <code>
- * class OpenProductActivityAuditEventBuilder{@code <T extends OpenProductActivityAuditEventBuilder<T>>}
- *         extends ActivityAuditEventBuilder{@code <T>} {
+ * class OpenProductActivityAuditEventBuilder&lt;T extends OpenProductActivityAuditEventBuilder&lt;T&gt;&gt;
+ *         extends ActivityAuditEventBuilder&lt;T&gt; {
  *
- *     public static {@code <T>} OpenProductActivityAuditEventBuilder{@code <?>} productActivityEvent() {
+ *     public static &lt;T&gt; OpenProductActivityAuditEventBuilder&lt;?&gt; productActivityEvent() {
  *         return new OpenProductActivityAuditEventBuilder();
  *     }
  *

--- a/commons/audit/core/src/main/java/org/forgerock/audit/events/AuthenticationAuditEventBuilder.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/events/AuthenticationAuditEventBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.events;
 
@@ -25,14 +26,14 @@ import java.util.Map;
  * new specific fields, e.g
  * <pre>
  * <code>
- * class OpenProductAuthenticationAuditEventBuilder{@code <T extends OpenProductAuthenticationAuditEventBuilder<T>>}
- extends AuthenticationAuditEventBuilder{@code <T>} {
+ * class OpenProductAuthenticationAuditEventBuilder&lt;T extends OpenProductAuthenticationAuditEventBuilder&lt;T&gt;&gt;
+ extends AuthenticationAuditEventBuilder&lt;T&gt; {
  *
  *    protected OpenProductAuthenticationAuditEventBuilder(DnsUtils dnsUtils) {
  *        super(dnsUtils);
  *    }
  *
- *    public static {@code <T>} OpenProductAuthenticationAuditEventBuilder{@code <?>} productAuthenticationEvent() {
+ *    public static &lt;T&gt; OpenProductAuthenticationAuditEventBuilder&lt;?&gt; productAuthenticationEvent() {
  *       return new OpenProductAuthenticationAuditEventBuilder(new DnsUtils());
  *    }
  *

--- a/commons/audit/core/src/main/java/org/forgerock/audit/events/ConfigAuditEventBuilder.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/events/ConfigAuditEventBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.events;
 
@@ -22,10 +23,10 @@ package org.forgerock.audit.events;
  * new specific fields, e.g
  * <pre>
  * <code>
- * class OpenProductConfigAuditEventBuilder{@code <T extends OpenProductConfigAuditEventBuilder<T>>}
- *         extends ConfigAuditEventBuilder{@code <T>} {
+ * class OpenProductConfigAuditEventBuilder&lt;T extends OpenProductConfigAuditEventBuilder&lt;T&gt;&gt;
+ *         extends ConfigAuditEventBuilder&lt;T&gt; {
  *
- *     public static {@code <T>} OpenProductConfigAuditEventBuilder{@code <?>} productConfigEvent() {
+ *     public static &lt;T&gt; OpenProductConfigAuditEventBuilder&lt;?&gt; productConfigEvent() {
  *         return new OpenProductConfigAuditEventBuilder();
  *     }
  *

--- a/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerConfiguration.java
+++ b/commons/audit/handler-jms/src/main/java/org/forgerock/audit/handlers/jms/JmsAuditEventHandlerConfiguration.java
@@ -33,7 +33,6 @@ import org.forgerock.util.Reject;
  * Configuration object for the {@link JmsAuditEventHandler}.
  * <p>
  * This configuration object can be created from JSON. Example of valid JSON configuration:
- * <p>
  * <pre>
  * {
  *     "name" : "jms",

--- a/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/OAuth2Module.java
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/OAuth2Module.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.authz.modules.oauth2;
@@ -94,10 +95,10 @@ public class OAuth2Module {
      * Determines whether a request is authorized to access the resource based on the validity of an access token
      * the scopes of the access token.
      *
-     * @param accessToken {@inheritDoc}
-     * @param context {@inheritDoc}
-     * @return {@inheritDoc}
-     * @throws AuthorizationException {@inheritDoc}
+     * @param accessToken the OAuth2 access token presented with the request
+     * @param context the authorization context for the request being authorized
+     * @return a promise of the authorization result for the request
+     * @throws AuthorizationException if the access token cannot be validated
      */
     public Promise<AuthorizationResult, AuthorizationException> authorize(String accessToken,
             final AuthorizationContext context) {

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/ErrorHandler.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/ErrorHandler.java
@@ -51,17 +51,14 @@ public abstract class ErrorHandler {
 
     /**
      * Receive notification of an error.
-     * <p>
      * <p>For example, a validator would use this callback to
      * report the violation of a validity constraint.
      * The default behaviour is to take no action.</p>
-     * <p>
      * <p>The validator must continue to provide normal validation
      * after invoking this method: it should still be possible
      * for the application to process the document through to the end.
      * If the application cannot do so, then the parser should report
      * a fatal error.</p>
-     * <p>
      * <p>Filters may use this method to report other, non-JSON errors
      * as well.</p>
      *

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/exceptions/SchemaException.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/exceptions/SchemaException.java
@@ -56,7 +56,6 @@ public class SchemaException extends JsonValueException {
 
     /**
      * Create a new SchemaException wrapping an existing exception.
-     * <p>
      * <p>The existing exception will be embedded in the new
      * one, and its message will become the default message for
      * the SchemaException.</p>
@@ -72,7 +71,6 @@ public class SchemaException extends JsonValueException {
 
     /**
      * Create a new SchemaException from an existing exception.
-     * <p>
      * <p>The existing exception will be embedded in the new
      * one, but the new exception will have its own message.</p>
      *
@@ -87,7 +85,6 @@ public class SchemaException extends JsonValueException {
 
     /**
      * Return a detail message for this exception.
-     * <p>
      * <p>If there is an embedded exception, and if the SchemaException
      * has no detail message of its own, this method will return
      * the detail message from the embedded exception.</p>

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/exceptions/ValidationException.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/exceptions/ValidationException.java
@@ -22,7 +22,6 @@ import org.forgerock.json.JsonPointer;
 
 /**
  * Encapsulate a JSON validator error.
- * <p>
  * <p>This exception may include information for locating the error
  * in the original JSON document object.  Note that although the application
  * will receive a ValidationException as the argument to the handlers
@@ -30,7 +29,6 @@ import org.forgerock.json.JsonPointer;
  * the application is not actually required to throw the exception;
  * instead, it can simply read the information in it and take a
  * different action.</p>
- * <p>
  * <p>Since this exception is a subclass of {@link SchemaException
  * SchemaException}, it inherits the ability to wrap another exception.</p>
  *

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/UnionTypeValidator.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/UnionTypeValidator.java
@@ -37,7 +37,6 @@ import static org.forgerock.json.schema.validator.Constants.*;
  * the simple validators definitions, or valid by one of the schemas, in
  * the array.
  * <p>
- * <p>
  * For example, a schema that defines if an instance can be a string or
  * a number would be:</p>
  * <p>

--- a/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/Validator.java
+++ b/commons/json-schema/core/src/main/java/org/forgerock/json/schema/validator/validators/Validator.java
@@ -62,7 +62,6 @@ public abstract class Validator implements SimpleValidator<Object> {
     /**
      * Gets the valid JSONPath of the node or the given property.
      * <p>
-     * <p>
      * Combines the two parameter and generates a valid JSONPath with dot–notation.
      * Simple type: $
      * Array type: $[0]

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/EncryptedJwtBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/EncryptedJwtBuilder.java
@@ -110,7 +110,6 @@ public class EncryptedJwtBuilder extends AbstractJwtBuilder {
 
     /**
      * Builds the JWE into a <code>String</code> by calling the <code>build</code> method on the JWE object.
-     * <p>
      * @see org.forgerock.json.jose.jwe.EncryptedJwt#build()
      *
      * @return The base64url encoded UTF-8 parts of the JWE.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/EncryptedThenSignedJwtBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/EncryptedThenSignedJwtBuilder.java
@@ -64,7 +64,6 @@ public class EncryptedThenSignedJwtBuilder extends AbstractJwtBuilder implements
 
     /**
      * Builds the JWS into a <code>String</code> by calling the <code>build</code> method on the JWS object.
-     * <p>
      * @see EncryptedThenSignedJwt#build()
      *
      * @return The base64url encoded UTF-8 parts of the JWS.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JweHeaderBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JweHeaderBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.builders;
@@ -42,7 +43,6 @@ public class JweHeaderBuilder<B extends EncryptedJwtBuilder> extends JwtSecureHe
 
     /**
      * Sets the Encryption Method header parameter for this JWE.
-     * <p>
      * @see org.forgerock.json.jose.jwe.JweHeader#setEncryptionMethod(org.forgerock.json.jose.jwe.EncryptionMethod)
      *
      * @param enc The Encryption Method.
@@ -55,7 +55,6 @@ public class JweHeaderBuilder<B extends EncryptedJwtBuilder> extends JwtSecureHe
 
     /**
      * Sets the Ephemeral Public Key header parameter for this JWE.
-     * <p>
      * @see org.forgerock.json.jose.jwe.JweHeader#setEphemeralPublicKey(org.forgerock.json.jose.jwk.JWK)
      *
      * @param epk The Ephemeral Public Key.
@@ -74,7 +73,6 @@ public class JweHeaderBuilder<B extends EncryptedJwtBuilder> extends JwtSecureHe
 
     /**
      * Sets the Agreement PartyUInfo header parameter for this JWE.
-     * <p>
      * @see org.forgerock.json.jose.jwe.JweHeader#setAgreementPartyUInfo(String)
      *
      * @param apu The Agreement PartyUInfo.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtBuilder.java
@@ -35,7 +35,6 @@ public interface JwtBuilder {
 
     /**
      * Builds the JWT into a <code>String</code> by calling the <code>build</code> method on the JWT object.
-     * <p>
      * @see org.forgerock.json.jose.jwt.Jwt#build()
      *
      * @return The base64url encoded UTF-8 parts of the JWT.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtClaimsSetBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtClaimsSetBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.builders;
@@ -39,7 +40,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Adds a custom claim to the JWT Claims Set.
-     * <p>
      * @see JwtClaimsSet#setClaim(String, Object)
      *
      * @param key The claim name.
@@ -53,7 +53,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets all of the claims the JWT Claims Set with the values contained in the specified map.
-     * <p>
      * @see JwtClaimsSet#setClaims(java.util.Map)
      *
      * @param claims The Map to use to set the claims.
@@ -66,7 +65,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the type of the contents of the Claims Set.
-     * <p>
      * @see JwtClaimsSet#getType()
      *
      * @param typ The Claims Set content type.
@@ -78,7 +76,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the unique ID of the JWT.
-     * <p>
      * @see JwtClaimsSet#setJwtId(String)
      *
      * @param jti The JWT's ID.
@@ -90,7 +87,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the issuer this JWT was issued by.
-     * <p>
      * @see JwtClaimsSet#setIssuer(String)
      *
      * @param iss The JWT's issuer.
@@ -102,7 +98,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the issuer this JWT was issued by.
-     * <p>
      * @see JwtClaimsSet#setIssuer(java.net.URI)
      *
      * @param iss The JWT's issuer.
@@ -114,7 +109,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the subject this JWT is issued to.
-     * <p>
      * @see JwtClaimsSet#setSubject(String)
      *
      * @param sub The JWT's subject.
@@ -126,7 +120,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the subject this JWT is issued to.
-     * <p>
      * @see JwtClaimsSet#setSubject(java.net.URI)
      *
      * @param sub The JWT's subject.
@@ -138,7 +131,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the JWT's intended audience list in the Claims Set.
-     * <p>
      * @see JwtClaimsSet#addAudience(String)
      *
      * @param aud The JWT's audience.
@@ -150,7 +142,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the time the JWT was issued at, in the Claims Set.
-     * <p>
      * @see JwtClaimsSet#setIssuedAtTime(java.util.Date)
      *
      * @param iat The JWT's issued at time.
@@ -162,7 +153,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the time the JWT is not allowed to be processed before, in the Claims Set.
-     * <p>
      * @see JwtClaimsSet#setNotBeforeTime(java.util.Date)
      *
      * @param nbf The JWT's not before time.
@@ -174,7 +164,6 @@ public class JwtClaimsSetBuilder {
 
     /**
      * Sets the expiration time of the JWT in the Claims Set.
-     * <p>
      * @see JwtClaimsSet#setExpirationTime(java.util.Date)
      *
      * @param exp The JWT's expiration time.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtHeaderBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtHeaderBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.builders;
@@ -49,7 +50,6 @@ public abstract class JwtHeaderBuilder<T extends JwtBuilder, B extends JwtHeader
 
     /**
      * Adds a custom header parameter to the JWT header.
-     * <p>
      * @see JwtHeader#setParameter(String, Object)
      *
      * @param key The header parameter key.
@@ -79,7 +79,6 @@ public abstract class JwtHeaderBuilder<T extends JwtBuilder, B extends JwtHeader
 
     /**
      * Sets the algorithm used to perform cryptographic signing and/or encryption on the JWT.
-     * <p>
      * @see JwtHeader#setAlgorithm(org.forgerock.json.jose.jwt.Algorithm)
      *
      * @param algorithm The algorithm.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtSecureHeaderBuilder.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/JwtSecureHeaderBuilder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.builders;
@@ -49,7 +50,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the JWK Set URL header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setJwkSetUrl(java.net.URL)
      *
      * @param jku The JWK Set URL.
@@ -63,7 +63,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the JSON Web Key header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setJsonWebKey(org.forgerock.json.jose.jwk.JWK)
      *
      * @param jwk The JSON Web Key.
@@ -77,7 +76,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the X.509 URL header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setX509Url(java.net.URL)
      *
      * @param x5u THe X.509 URL.
@@ -91,7 +89,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the X.509 Certificate Thumbprint header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setX509CertificateThumbprint(String)
      *
      * @param x5t The X.509 Certificate Thumbprint.
@@ -105,7 +102,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the X.509 Certificate Chain header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setX509CertificateChain(java.util.List)
      *
      * @param x5c The X.509 Certificate Chain.
@@ -119,7 +115,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the Key ID header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setKeyId(String)
      *
      * @param kid The Key ID.
@@ -133,7 +128,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the content type header parameter for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setContentType(String)
      *
      * @param cty The content type of the JWS payload.
@@ -147,7 +141,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the critical header parameters for this JWS.
-     * <p>
      * @see org.forgerock.json.jose.jws.JwtSecureHeader#setCriticalHeaders(java.util.List)
      *
      * @param crit A List of the JWS critical parameters.
@@ -161,7 +154,6 @@ public abstract class JwtSecureHeaderBuilder<T extends JwtBuilder, B extends Jwt
 
     /**
      * Sets the Compression Algorithm header parameter for this JWE.
-     * <p>
      * @see JwtSecureHeader#setCompressionAlgorithm(CompressionAlgorithm)
      *
      * @param zip The Compression Algorithm.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/SignedJwtBuilderImpl.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/builders/SignedJwtBuilderImpl.java
@@ -92,7 +92,6 @@ public class SignedJwtBuilderImpl extends AbstractJwtBuilder implements SignedJw
 
     /**
      * Builds the JWS into a <code>String</code> by calling the <code>build</code> method on the JWS object.
-     * <p>
      * @see org.forgerock.json.jose.jws.SignedJwt#build()
      *
      * @return The base64url encoded UTF-8 parts of the JWS.

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/CompressionAlgorithm.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/CompressionAlgorithm.java
@@ -12,13 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwe;
 
 /**
  * An Enum of the possible compression algorithms that can be applied to the JWE payload plaintext.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-encryption-11#section-4.1.4">
  *     JWE Compression Algorithm</a>
  *

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/EncryptedJwt.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/EncryptedJwt.java
@@ -33,7 +33,6 @@ import org.forgerock.util.encode.Base64url;
  * A JWE implementation of the <code>Jwt</code> interface.
  * <p>
  * JSON Web Encryption (JWE) is a representing encrypted content using JSON based data structures.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-encryption-11">
  *     JSON Web Encryption Specification</a>
  *

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/EncryptionMethod.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/EncryptionMethod.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwe;
@@ -22,7 +23,6 @@ import org.forgerock.json.jose.exceptions.JweException;
 
 /**
  * An Enum of the possible encryption methods that can be used when encrypting a JWT.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-11#section-4.2">
  *     JWE Encryption Methods</a>
  *

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/JweAlgorithm.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/JweAlgorithm.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwe;
@@ -21,7 +22,6 @@ import org.forgerock.json.jose.jwt.Algorithm;
 
 /**
  * An Enum of the possible encryption algorithms that can be used to encrypt a JWT.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-11#section-4.1">JWE Algorithms</a>
  *
  * @since 2.0.0

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/handlers/compression/DeflateCompressionHandler.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwe/handlers/compression/DeflateCompressionHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwe.handlers.compression;
@@ -28,7 +29,6 @@ import org.forgerock.json.jose.exceptions.JweCompressionException;
 
 /**
  * An implementation of the CompressionHandler for DEFLATE Compressed Data Format Specification.
- * <p>
  * @see <a href="http://tools.ietf.org/html/rfc1951">DEFLATE Compressed Data Format Specification version 1.3</a>
  *
  */

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/EncryptedThenSignedJwt.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/EncryptedThenSignedJwt.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jws;
@@ -25,7 +26,6 @@ import java.security.Key;
 
 /**
  * An implementation of a JWS with a nested JWE as its payload.
- * <p>
  * @see SignedJwt
  * @see EncryptedJwt
  *

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwsAlgorithm.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwsAlgorithm.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jws;
@@ -20,7 +21,6 @@ import org.forgerock.json.jose.jwt.Algorithm;
 
 /**
  * An Enum of the possible signing algorithms that can be used to sign a JWT.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-11#section-3.1">JWS Algorithms</a>
  *
  * @since 2.0.0

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jws;
@@ -186,7 +187,6 @@ public abstract class JwtSecureHeader extends JwtHeader {
      * The certificate containing the public key corresponding to the key used to digitally sign the JWS MUST be the
      * first certificate. This MAY be followed by additional certificates, with each subsequent certificate being the
      * one used to certify the previous one.
-     * <p>
      *
      * @param x509CertificateChain The X.509 Certificate Chain.
      */

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/SignedJwt.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/SignedJwt.java
@@ -30,7 +30,6 @@ import org.forgerock.util.encode.Base64url;
  * <p>
  * JSON Web Signature (JWS) is a means of representing content secured with digital signatures or Message
  * Authentication Codes (MACs) using JSON based data structures.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-11">JSON Web Signature Specification</a>
  *
  * @since 2.0.0

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Algorithm.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Algorithm.java
@@ -12,13 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwt;
 
 /**
  * The interface for each possible algorithm that can be used to sign and/or encrypt a JWT.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-11">
  *     JSON Web Algorithms Specification</a>
  *

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Jwt.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Jwt.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwt;
@@ -22,7 +23,6 @@ package org.forgerock.json.jose.jwt;
  * JSON Web Token (JWT) is a means of representing claims to be transferred between two parties.  The claims in a JWT
  * are encoded as a JSON object that is digitally signed or MACed using JSON Web Signature (JWS) and/or encrypted using
  * JSON Web Encryption (JWE).
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-jones-json-web-token-10">JSON Web Token Specification</a>
  *
  * @since 2.0.0
@@ -50,7 +50,6 @@ public interface Jwt {
     /**
      * Builds the JWT into a <code>String</code> by following the steps specified in the relevant specification
      * according to whether the JWT is being signed and/or encrypted.
-     * <p>
      * @see <a href="http://tools.ietf.org/html/draft-jones-json-web-token-10#section-7">
      *     JSON Web Token Specification</a>
      * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-11#section-5">

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSetKey.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/JwtClaimsSetKey.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwt;
@@ -26,7 +27,6 @@ import java.util.Map;
  * <p>
  * As described in the JWT specification, this Enum class represents all the reserved JWT Claim Names, any other Claim
  * name is deemed as a "custom" Claim name.
- * <p>
  * @see <a href="http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.1">Reserved Claim Names</a>
  *
  * @since 2.0.0

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Payload.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jwt/Payload.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.json.jose.jwt;
@@ -30,7 +31,6 @@ public interface Payload {
     /**
      * Builds the JWTs Payload into a <code>String</code> by following the steps specified in the relevant specification
      * according to whether the JWT is being signed and/or encrypted.
-     * <p>
      * @see <a href="http://tools.ietf.org/html/draft-jones-json-web-token-10#section-7">
      *     JSON Web Token Specification</a>
      * @see <a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-11#section-5">

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/markup/asciidoc/AsciiDoc.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/markup/asciidoc/AsciiDoc.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.api.markup.asciidoc;
@@ -584,7 +585,6 @@ public final class AsciiDoc {
 
     /**
      * Converts builder content to a {@code String}.
-     * <p>
      *
      * @return Doc builder content
      */

--- a/commons/util/util/src/main/java/org/forgerock/json/JsonPointer.java
+++ b/commons/util/util/src/main/java/org/forgerock/json/JsonPointer.java
@@ -169,26 +169,27 @@ public class JsonPointer implements Iterable<String> {
      * reference tokens.
      * <p>
      * This method yields the following results: <blockquote>
-     * <table cellpadding=1 cellspacing=0 summary="Examples illustrating usage of relativePointer">
+     * <table>
+     * <caption>Examples illustrating usage of relativePointer</caption>
      * <tr>
      * <th>Input</th>
      * <th>Output</th>
      * </tr>
      * <tr>
-     * <td align=left>/</td>
-     * <td align=left><code>/</code></td>
+     * <td>/</td>
+     * <td><code>/</code></td>
      * </tr>
      * <tr>
-     * <td align=left>/a</td>
-     * <td align=left><code>/</code></td>
+     * <td>/a</td>
+     * <td><code>/</code></td>
      * </tr>
      * <tr>
-     * <td align=left>/a/b</td>
-     * <td align=left>/b</td>
+     * <td>/a/b</td>
+     * <td>/b</td>
      * </tr>
      * <tr>
-     * <td align=left>/a/b/c</td>
-     * <td align=left>/b/c</td>
+     * <td>/a/b/c</td>
+     * <td>/b/c</td>
      * </tr>
      * </table>
      * </blockquote>
@@ -205,31 +206,32 @@ public class JsonPointer implements Iterable<String> {
      * contained in this pointer.
      * <p>
      * This method yields the following results: <blockquote>
-     * <table cellpadding=1 cellspacing=0 summary="Examples illustrating usage of relativePointer">
+     * <table>
+     * <caption>Examples illustrating usage of relativePointer(int)</caption>
      * <tr>
      * <th>Input</th>
      * <th>sz</th>
      * <th>Output</th>
      * </tr>
      * <tr>
-     * <td align=left>/a/b/c</td>
-     * <td align=center>0</td>
-     * <td align=left>/</td>
+     * <td>/a/b/c</td>
+     * <td>0</td>
+     * <td>/</td>
      * </tr>
      * <tr>
-     * <td align=left>/a/b/c</td>
-     * <td align=center>1</td>
-     * <td align=left>/c</td>
+     * <td>/a/b/c</td>
+     * <td>1</td>
+     * <td>/c</td>
      * </tr>
      * <tr>
-     * <td align=left>/a/b/c</td>
-     * <td align=center>2</td>
-     * <td align=left>/b/c</td>
+     * <td>/a/b/c</td>
+     * <td>2</td>
+     * <td>/b/c</td>
      * </tr>
      * <tr>
-     * <td align=left>/a/b/c</td>
-     * <td align=center>3</td>
-     * <td align=left>/a/b/c</td>
+     * <td>/a/b/c</td>
+     * <td>3</td>
+     * <td>/a/b/c</td>
      * </tr>
      * </table>
      * </blockquote>

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/AbstractExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/AbstractExternalDependencyMojo.java
@@ -63,6 +63,13 @@ public abstract class AbstractExternalDependencyMojo extends
 {
 
     /**
+     * Creates a new instance.
+     */
+    protected AbstractExternalDependencyMojo()
+    {
+    }
+
+    /**
      * Used to look up Artifacts in the remote repository.
      * 
      * @component
@@ -80,6 +87,8 @@ public abstract class AbstractExternalDependencyMojo extends
     protected ArrayList<ArtifactItem> artifactItems;
 
     /**
+     * The Maven project the plugin is operating on.
+     *
      * @parameter default-value="${project}"
      * @required
      * @readonly
@@ -87,6 +96,8 @@ public abstract class AbstractExternalDependencyMojo extends
     protected MavenProject project;
 
     /**
+     * The staging directory where downloaded artifacts are placed.
+     *
      * @parameter default-value="${project.build.directory}"
      */
     protected String stagingDirectory;
@@ -113,6 +124,7 @@ public abstract class AbstractExternalDependencyMojo extends
      * Create Maven Artifact object from ArtifactItem configuration descriptor
      * 
      * @param item
+     *            the artifact item describing the artifact to create
      * @return Artifact
      */
     protected Artifact createArtifact(ArtifactItem item)
@@ -132,6 +144,8 @@ public abstract class AbstractExternalDependencyMojo extends
      * responsibility of the caller to delete the generated file when no longer
      * needed.
      * 
+     * @param artifact
+     *            the artifact item to generate a POM file for
      * @return The path to the generated POM file, never <code>null</code>.
      * @throws MojoExecutionException
      *             If the POM file could not be generated.
@@ -166,6 +180,8 @@ public abstract class AbstractExternalDependencyMojo extends
     /**
      * Generates a minimal model from the user-supplied artifact information.
      * 
+     * @param artifact
+     *            the artifact item to generate a model from
      * @return The generated model, never <code>null</code>.
      */
     protected Model generateModel(ArtifactItem artifact)
@@ -184,6 +200,8 @@ public abstract class AbstractExternalDependencyMojo extends
      * Resolves the file path and returns a file object instance for an artifact
      * item
      * 
+     * @param artifactItem
+     *            the artifact item whose file path is resolved
      * @return File object for artifact item
      */
     protected File getFullyQualifiedArtifactFilePath(ArtifactItem artifactItem)
@@ -206,6 +224,9 @@ public abstract class AbstractExternalDependencyMojo extends
      *            not be <code>null</code>.
      * @param digester
      *            The checksum algorithm to use, must not be <code>null</code>.
+     * @param checksum
+     *            the expected checksum to compare against
+     * @return <code>true</code> if the calculated checksum matches the expected checksum
      * @throws MojoExecutionException
      *             If the checksum could not be installed.
      */
@@ -238,8 +259,11 @@ public abstract class AbstractExternalDependencyMojo extends
      * @param targetFile
      *            to validate checksum against
      * @throws MojoExecutionException
+     *             if the checksum cannot be calculated
      * @throws MojoFailureException
+     *             if checksum verification fails
      * @throws IOException
+     *             if the target file cannot be read
      */
     protected void verifyArtifactItemChecksum(ArtifactItem artifactItem,
             File targetFile) throws MojoExecutionException,
@@ -311,8 +335,11 @@ public abstract class AbstractExternalDependencyMojo extends
      * @param targetFile
      *            to validate checksum against
      * @throws MojoExecutionException
+     *             if the checksum cannot be calculated
      * @throws MojoFailureException
+     *             if checksum verification fails
      * @throws IOException
+     *             if the extracted file cannot be read
      */
     protected void verifyArtifactItemExtractFileChecksum(ArtifactItem artifactItem,
             File targetFile) throws MojoExecutionException,
@@ -389,8 +416,11 @@ public abstract class AbstractExternalDependencyMojo extends
      * @param targetFile
      *            to validate checksum against
      * @throws MojoExecutionException
+     *             if the Sonatype checksum lookup cannot be performed
      * @throws MojoFailureException
+     *             if a matching artifact is found in a public repository
      * @throws IOException
+     *             if the target file cannot be read
      */
     protected void verifyArtifactItemChecksumBySonatypeLookup(ArtifactItem artifactItem,
         File targetFile) throws MojoExecutionException,

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
@@ -253,6 +253,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the artifact identifier.
+     *
      * @return Returns the artifactId.
      */
     public final String getArtifactId()
@@ -272,6 +274,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the group identifier.
+     *
      * @return Returns the groupId.
      */
     public final String getGroupId()
@@ -280,6 +284,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the group identifier.
+     *
      * @param groupId
      *            The groupId to set.
      */
@@ -289,6 +295,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the artifact type (its packaging).
+     *
      * @return Returns the type.
      */
     public final String getType()
@@ -297,6 +305,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the artifact version.
+     *
      * @return Returns the version.
      */
     public final String getVersion()
@@ -305,6 +315,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the artifact version.
+     *
      * @param version
      *            The version to set.
      */
@@ -314,6 +326,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the artifact classifier.
+     *
      * @return Classifier.
      */
     public final String getClassifier()
@@ -322,6 +336,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the artifact classifier.
+     *
      * @param classifier
      *            Classifier.
      */
@@ -350,6 +366,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the local file path, with tokens resolved.
+     *
      * @return Returns the location.
      */
     public final String getLocalFile()
@@ -358,6 +376,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the local file path.
+     *
      * @param localFile
      *            The localFile to set.
      */
@@ -367,6 +387,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the staging directory, with tokens resolved.
+     *
      * @return Returns the stagingDirectory.
      */
     public final String getStagingDirectory()
@@ -375,6 +397,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the staging directory.
+     *
      * @param stagingDirectory
      *            The stagingDirectory to set.
      */
@@ -384,6 +408,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the source URL the artifact is downloaded from.
+     *
      * @return Returns the source URL to download the artifact.
      */
     public final String getDownloadUrl()
@@ -392,6 +418,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the source URL to download the artifact from.
+     *
      * @param downloadUrl
      *            Set the URL to download the artifact from.
      */
@@ -401,6 +429,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the download timeout in milliseconds.
+     *
      * @return Returns the timeout in millis allowed for artifact download.
      */
     public final Integer getTimeout()
@@ -409,6 +439,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the raw, unresolved download timeout.
+     *
      * @return Raw timeout value as configured (may be null) so callers can
      *         distinguish an explicitly set per-artifact timeout from the
      *         default fallback returned by {@link #getTimeout()}.
@@ -419,6 +451,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the download timeout in milliseconds.
+     *
      * @param timeout
      *            Set the timeout in millis allowed for artifact download.
      */
@@ -428,6 +462,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the configured number of download retry attempts.
+     *
      * @return Raw retry attempts value as configured (may be null).
      */
     public final Integer getRetryAttempts()
@@ -436,6 +472,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the number of download retry attempts.
+     *
      * @param retryAttempts
      *            Number of attempts to download the artifact in case of
      *            transient network failures.
@@ -446,6 +484,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the configured delay between download retries.
+     *
      * @return Raw retry delay value (in millis) as configured (may be null).
      */
     public final Integer getRetryDelay()
@@ -454,6 +494,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the delay between download retries.
+     *
      * @param retryDelay
      *            Delay in millis between download retry attempts.
      */
@@ -463,6 +505,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the artifact packaging.
+     *
      * @return Packaging.
      */
     public final String getPackaging()
@@ -471,6 +515,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the artifact packaging.
+     *
      * @param packaging
      *            Packaging.
      */
@@ -480,6 +526,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether the artifact download is forced.
+     *
      * @return Force.
      */
     public final Boolean getForce()
@@ -488,6 +536,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether the artifact download is forced.
+     *
      * @param force
      *            Force.
      */
@@ -497,6 +547,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether the artifact is installed.
+     *
      * @return Install.
      */
     public final Boolean getInstall()
@@ -505,6 +557,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether the artifact is installed.
+     *
      * @param install
      *            Install.
      */
@@ -514,6 +568,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether the artifact is deployed.
+     *
      * @return Deploy.
      */
     public final Boolean getDeploy()
@@ -522,6 +578,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether the artifact is deployed.
+     *
      * @param deploy
      *            Deploy.
      */
@@ -531,6 +589,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the POM file associated with the artifact.
+     *
      * @return PomFile.
      */
     public final File getPomFile()
@@ -539,6 +599,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the POM file associated with the artifact.
+     *
      * @param pomFile
      *            PomFile.
      */
@@ -548,6 +610,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether a POM is generated for the artifact.
+     *
      * @return GeneratePom.
      */
     public final Boolean getGeneratePom()
@@ -556,6 +620,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether a POM is generated for the artifact.
+     *
      * @param generatePom
      *            GeneratePom.
      */
@@ -565,6 +631,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the checksum-creation setting.
+     *
      * @return CreateChecksum.
      */
     public final String getCreateChecksum()
@@ -573,6 +641,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the checksum-creation setting.
+     *
      * @param createChecksum
      *            CreateChecksum.
      */
@@ -582,6 +652,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns the expected checksum of the artifact.
+     *
      * @return Checksum.
      */
     public final String getChecksum()
@@ -590,6 +662,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether a checksum is defined.
+     *
      * @return true is a checksum was defined.
      */
     public final boolean hasChecksum()
@@ -598,6 +672,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether a checksum is defined for an extracted file.
+     *
      * @return true is a checksum was defined for an extracted file.
      */
     public final boolean hasExtractFileChecksum()
@@ -606,6 +682,8 @@ public class ArtifactItem
     }
     
     /**
+     * Returns the expected checksum of the extracted file.
+     *
      * @return Extracted File Checksum.
      */    
     public final String getExtractFileChecksum()
@@ -615,6 +693,8 @@ public class ArtifactItem
     
     
     /**
+     * Sets the expected checksum of the artifact.
+     *
      * @param checksum
      *            Checksum
      */
@@ -624,6 +704,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether checksum verification is skipped.
+     *
      * @return SkipChecksumVerification.
      */
     public final Boolean getSkipChecksumVerification()
@@ -632,6 +714,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether checksum verification is skipped.
+     *
      * @param skipChecksumVerification
      *            SkipChecksumVerification.
      */
@@ -643,6 +727,8 @@ public class ArtifactItem
     
     
     /**
+     * Returns the path of the file to extract, with tokens resolved.
+     *
      * @return ExtractFile.
      */
     public final String getExtractFile()
@@ -651,6 +737,8 @@ public class ArtifactItem
     }
 
     /**
+     * Returns whether a file to extract is defined.
+     *
      * @return true is an extractFile was defined.
      */
     public final boolean hasExtractFile()
@@ -659,6 +747,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets the path of the file to extract.
+     *
      * @param extractFile
      *            ExtractFile
      */
@@ -731,17 +821,30 @@ public class ArtifactItem
         return target;
     }
 
+    /**
+     * Returns whether the artifact should be repacked.
+     *
+     * @return <code>true</code> if the artifact should be repacked
+     */
     public boolean isRepack()
     {
         return repack;
     }
 
+    /**
+     * Sets whether the artifact should be repacked.
+     *
+     * @param repack
+     *            <code>true</code> if the artifact should be repacked
+     */
     public void setRepack(boolean repack)
     {
         this.repack = repack;
     }
 
     /**
+     * Returns whether the POM is extracted from the artifact.
+     *
      * @return ExtractPom.
      */
     public final Boolean getExtractPom()
@@ -750,6 +853,8 @@ public class ArtifactItem
     }
 
     /**
+     * Sets whether the POM is extracted from the artifact.
+     *
      * @param extractPom
      *            ExtractPom.
      */

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/CleanExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/CleanExternalDependencyMojo.java
@@ -29,6 +29,13 @@ import org.apache.maven.plugin.MojoFailureException;
  */
 public class CleanExternalDependencyMojo extends AbstractExternalDependencyMojo
 {
+    /**
+     * Creates a new instance.
+     */
+    public CleanExternalDependencyMojo()
+    {
+    }
+
     public void execute() throws MojoExecutionException, MojoFailureException
     {
         try

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/DeployExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/DeployExternalDependencyMojo.java
@@ -42,6 +42,15 @@ public class DeployExternalDependencyMojo extends
         AbstractExternalDependencyMojo
 {
     /**
+     * Creates a new instance.
+     */
+    public DeployExternalDependencyMojo()
+    {
+    }
+
+    /**
+     * The local repository into which the artifact is deployed.
+     *
      * @parameter expression="${localRepository}"
      * @required
      * @readonly

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/InstallExternalDependencyMojo.java
@@ -38,6 +38,15 @@ public class InstallExternalDependencyMojo extends
     AbstractExternalDependencyMojo
 {
     /**
+     * Creates a new instance.
+     */
+    public InstallExternalDependencyMojo()
+    {
+    }
+
+    /**
+     * The local repository into which the artifact is installed.
+     *
      * @parameter expression="${localRepository}"
      * @required
      * @readonly
@@ -45,6 +54,8 @@ public class InstallExternalDependencyMojo extends
     protected ArtifactRepository localRepository;
 
     /**
+     * The artifact installer used to install artifacts.
+     *
      * @component
      */
     protected ArtifactInstaller installer;

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
@@ -54,6 +54,15 @@ public class ResolveExternalDependencyMojo extends
     AbstractExternalDependencyMojo
 {
     /**
+     * Creates a new instance.
+     */
+    public ResolveExternalDependencyMojo()
+    {
+    }
+
+    /**
+     * The local repository used to resolve artifacts.
+     *
      * @parameter expression="${localRepository}"
      * @required
      * @readonly
@@ -78,6 +87,8 @@ public class ResolveExternalDependencyMojo extends
     protected java.util.List remoteRepositories;
 
     /**
+     * The archiver manager used to unpack resolved artifacts.
+     *
      * @component
      * @readonly
      */
@@ -492,8 +503,10 @@ public class ResolveExternalDependencyMojo extends
      * resolve the artifact in local or remote repository
      *
      * @param artifact
-     * @return
+     *            the artifact to resolve
+     * @return <code>true</code> if the artifact was resolved
      * @throws MojoFailureException
+     *             if the artifact cannot be resolved
      */
     protected boolean resolveArtifactItem(Artifact artifact)
         throws MojoFailureException

--- a/persistit/core/src/main/java/com/persistit/Configuration.java
+++ b/persistit/core/src/main/java/com/persistit/Configuration.java
@@ -640,8 +640,6 @@ public class Configuration {
          * </pre>
          * reserves 128M from available memory and then allocates
          * 75% of the remainder up to 8Gb, but not less than 64Mb.
-         * <p>
-         * </p>
          * 
          * @param bufferSize
          * @param propertyName

--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -103,7 +103,6 @@ import static com.persistit.util.ThreadSequencer.sequence;
  * modify the database and return the former value associated with the current
  * <code>Key</code>.
  * </p>
- * <p>
  * <h2>Exchange is Not Threadsafe</h2>
  * <em>Important:</em> an <code>Exchange</code> and its associated
  * <code>Key</code> and <code>Value</code> instances are <i>not</i> thread-safe.
@@ -116,7 +115,6 @@ import static com.persistit.util.ThreadSequencer.sequence;
  * Persistit is designed to allow multiple threads, using <em>multiple</em>
  * <code>Exchange</code> instances, to access and update the underlying database
  * in a highly concurrent fashion.
- * <p>
  * <h2>Exchange Pools</h2>
  * Normally each thread should allocate its own <code>Exchange</code> instances.
  * However, depending on the garbage collection performance characteristics of a
@@ -2778,8 +2776,6 @@ public class Exchange implements ReadOnlyExchange {
    * Isolation. See, for example, http://wikipedia.org/wiki/Snapshot_isolation
    * for a concise explanation of Snapshot Isolation and the write skew
    * anomaly.
-   * <p>
-   * </p>
    * To use this facility an application specifies a key which may or may not
    * be associated with an actual storage location, but which is designed to
    * conflict with any other transaction that could participate in a write

--- a/persistit/core/src/main/java/com/persistit/JournalRecord.java
+++ b/persistit/core/src/main/java/com/persistit/JournalRecord.java
@@ -50,7 +50,6 @@ import com.persistit.util.Util;
  * </table>
  * <p>
  * Type: two ASCII bytes:
- * <p>
  * <table border="1">
  * <caption>Summary</caption>
  * 

--- a/persistit/core/src/main/java/com/persistit/KeyFilter.java
+++ b/persistit/core/src/main/java/com/persistit/KeyFilter.java
@@ -1451,7 +1451,6 @@ public class KeyFilter {
      * only values in this subset. The following definitions are used in
      * describing the behavior of this method.
      * </p>
-     * <p>
      * <dl>
      * <dt>Range</dt>
      * <dd>Let S be the ordered set of all possible key values. (Though large,
@@ -1481,8 +1480,6 @@ public class KeyFilter {
      * this method returns <code>true</code> and does not modify the key. The
      * exception is that if the current key is selected, the direction is LT or
      * GT, and there is no adjacent key in the range, this method w
-     * <p>
-     * </p>
      * Similarly, if key is {12} and then the directions LTEQ and LT result in
      * key values {10} and {10}+, respectively.
      * <p>

--- a/persistit/core/src/main/java/com/persistit/KeyHistogram.java
+++ b/persistit/core/src/main/java/com/persistit/KeyHistogram.java
@@ -27,14 +27,10 @@ import java.util.List;
  * {@link Exchange#computeHistogram(Key, Key, int, int, KeyFilter, int)} method
  * to accumulate and return the result of scanning all the keys at a fixed depth
  * within a Tree.
- * <p>
- * </p>
  * The result is represented by a List of {@link KeyCount} objects, each
  * representing a key and a count. The count represents the number of smaller
  * keys in the tree level. With this information client applications can
  * estimate the number of elements between any two keys in the Tree.
- * <p>
- * </p>
  * Application code can specify a <code>keyDepth</code> at which sibling keys
  * are grouped together. For example, suppose a Tree contains keys such as
  * 
@@ -50,15 +46,11 @@ import java.util.List;
  * with a <code>count</code> value of 1.  But if <code>keyDepth=1</code> the
  * result will have two buckets, one each for "BLUE" and "RED". Specifying
  * <code>keyDepth=0</code> turns off aggregation by partial key depth.
- * <p>
- * </p>
  * During the aggregation process the {@link Exchange#computeHistogram} method
  * invokes the {@link #addKeyCopy} method for each Key it traverses. Each key is
  * analyzed to determine whether the first <code>keyDepth</code> segments are
  * the same as the previously added Key. If so then the previous count is
  * incremented; otherwise a new KeyCount entry is added to the sample list.
- * <p>
- * </p>
  * 
  * 
  * @author peter

--- a/persistit/core/src/main/java/com/persistit/PersistitMap.java
+++ b/persistit/core/src/main/java/com/persistit/PersistitMap.java
@@ -679,7 +679,6 @@ public class PersistitMap<K, V> extends AbstractMap<K, V> implements SortedMap<K
      * This implementation iterates over the specified map's
      * <code>entrySet()</code> collection, and calls this map's <code>put</code>
      * operation once for each entry returned by the iteration.
-     * <p>
      * 
      * @param t
      *            mappings to be stored in this map.
@@ -1349,7 +1348,6 @@ public class PersistitMap<K, V> extends AbstractMap<K, V> implements SortedMap<K
      * as the key followed by an equals sign (<code>"="</code>) followed by the
      * associated value. Keys and values are converted to strings as by
      * <code>String.valueOf(Object)</code>.
-     * <p>
      * 
      * @return a String representation of this map.
      */

--- a/persistit/core/src/main/java/com/persistit/VolumeSpecification.java
+++ b/persistit/core/src/main/java/com/persistit/VolumeSpecification.java
@@ -163,7 +163,6 @@ public class VolumeSpecification {
      * extend.</dd>
      * 
      * </dl>
-     * <p>
      * 
      * @param specification
      *            the specification String

--- a/pom.xml
+++ b/pom.xml
@@ -1060,6 +1060,12 @@
                             <tag><name>readonly</name><placement>a</placement><head>Read-only:</head></tag>
                             <tag><name>threadSafe</name><placement>a</placement><head>Thread-safe:</head></tag>
                         </tags>
+                        <!-- Suppress the doclint "missing" group (no comment, no main
+                             description, missing @param/@return/@throws, default constructor)
+                             across the reactor. These are non-fatal documentation-completeness
+                             warnings surfaced as CI annotations; keep the accessibility, html,
+                             reference and syntax checks that guard against real javadoc errors. -->
+                        <doclint>all,-missing</doclint>
                         <author>false</author>
                         <quiet>true</quiet>
                         <windowtitle>${javadocWindowTitle}</windowtitle>

--- a/script/common/src/main/java/org/forgerock/script/engine/CompiledScript.java
+++ b/script/common/src/main/java/org/forgerock/script/engine/CompiledScript.java
@@ -39,7 +39,6 @@ public interface CompiledScript {
 
     /**
      * Evaluated the script stored in this {@code CompiledScript} object.
-     * <p>
      *
      * @param context
      *            A {@code context} associated with the

--- a/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScript.java
+++ b/script/groovy/src/main/java/org/forgerock/script/groovy/GroovyScript.java
@@ -36,6 +36,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 /**
@@ -86,7 +87,6 @@ import groovy.util.ResourceException;
  * <p>
  * This implementation pre-compiles the provided script. Any syntax errors in
  * the source code will throw an exception during construction of the object.
- * <p>
  *
  * @author Paul C. Bryan
  * @author aegloff

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
@@ -18,6 +18,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.script.javascript;
@@ -62,7 +63,6 @@ import org.slf4j.LoggerFactory;
  * <p>
  * This implementation pre-compiles the provided script. Any syntax errors in
  * the source code will throw an exception during construction of the object.
- * <p>
  *
  * @author Paul C. Bryan
  * @author aegloff


### PR DESCRIPTION
## Problem

`mvn package` runs `maven-javadoc-plugin:jar` on every module. On the JDK build jobs the standard doclet emits ~880 "missing documentation" warnings (no comment, no `@param`/`@return`, default constructor) across 56 modules. GitHub caps annotations at 10 per job, so CI surfaces 20 annotations (10 × two jobs) — all of them coming from `AbstractExternalDependencyMojo`, the first module in reactor order to produce them.

## Change

Enable strict doclint but drop only the noisy `missing` group:

- `pom.xml`: `<doclint>all,-missing</doclint>` — suppresses the documentation-completeness warnings repo-wide while keeping the `html`, `reference`, `syntax` and `accessibility` checks that catch real javadoc errors.

Turning those checks on surfaced 26 real errors + 89 warnings that were previously hidden behind the noise; all are fixed so the reactor javadoc is clean:

- `JsonPointer`: two legacy HTML tables converted to HTML5 — drop `cellpadding`/`cellspacing`/`summary`/`align`, add `<caption>` (the 26 `attribute not supported in HTML5` errors).
- 43 files: remove empty `<p>` paragraphs and escape `{@code}` nested inside `<code>`.
- `OAuth2Module`: replace non-inherited `{@inheritDoc}` tags with real descriptions.
- `maven-external-dependency-plugin` mojos: add the missing Javadoc.

## Verification

Full reactor build (`mvn package`, JDK 26):

- **BUILD SUCCESS**
- javadoc warnings: **878 → 0**
- javadoc errors: **26 → 0**
