### PR TITLE
Scan JavaScript/TypeScript, Python and Actions with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,14 @@ jobs:
           # this to 'manual' and uncomment the "Build with Maven" step below.
           - language: java-kotlin
             build-mode: none
+          # Interpreted languages: no compilation, extracted straight from source.
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          # Scans the repository's own GitHub Actions workflows.
+          - language: actions
+            build-mode: none
 
     steps:
       - name: Checkout repository
@@ -64,6 +72,12 @@ jobs:
             paths-ignore:
               - '**/src/test/**'
               - '**/src/it/**'
+              # Third-party / vendored JavaScript — analysing it only adds noise.
+              - '**/*.min.js'
+              - '**/node_modules/**'
+              - '**/webjars/**'
+              - '**/doc-maven-plugin/src/main/resources/js/**'
+              - '**/openapi-war-overlay/**/swagger-ui.js'
 
       # --- Manual build (only used when build-mode is 'manual') -------------
       # - name: Set up JDK 11


### PR DESCRIPTION
## What

Extend the CodeQL analysis matrix beyond `java-kotlin` to also scan:

| Language | Why |
|---|---|
| `javascript-typescript` | First-party JS in the self-service example UI and the openapi translators. |
| `python` | `persistit` docs (`conf.py`) and the stress-test helper script. |
| `actions` | The repository's own GitHub Actions workflows. |

All languages use `build-mode: none` (no compilation needed — CodeQL extracts straight from source).

## Noise control

Added `paths-ignore` entries so the JavaScript analysis skips minified and vendored third-party code instead of reporting findings on code we do not maintain:

- `**/*.min.js`
- `**/node_modules/**`
- `**/webjars/**`
- `**/doc-maven-plugin/src/main/resources/js/**` (SyntaxHighlighter)
- `**/openapi-war-overlay/**/swagger-ui.js`

## Not included

- **Ruby** — the only `.rb` file is an AsciiDoc extension (`nested-open-block.rb`), not application code.
- **Groovy** — not supported by CodeQL as a standalone language.

## Notes

Java/Kotlin analysis is unchanged (still `build-mode: none`, `security-and-quality` queries, tests/IT excluded). The three added languages are cheap, so they run on every push/PR alongside the existing schedule.
