### PR TITLE
Fix flaky WarmupTest.testWarmup (compare resident page set, not slot order)

### DIFF
--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class WarmupTest extends PersistitUnitTestCase {
@@ -51,18 +52,34 @@ public class WarmupTest extends PersistitUnitTestCase {
      * It does not guarantee that a page returns to the same buffer slot:
      * preloadBufferInventory() sorts the recorded pages by read order and
      * reallocates buffers via the clock algorithm, so the slot index is not
-     * preserved. Compare the set of resident pages, not per-slot correspondence
-     * (the latter only happened to match and made the test flaky).
+     * preserved. The old per-slot assertion depended on the exact interleaving
+     * of the preload order and background eviction/cleanup between shutdown and
+     * the snapshot, which is why it passed on most JVMs but failed on the JDK 17
+     * runner (expected:<0> but was:<2> -- an empty slot where the page was still
+     * resident, just relocated). Compare the set of resident pages instead.
      */
     final Set<String> before = residentPages(pool);
-    assertTrue("Test setup should leave pages resident in the pool", !before.isEmpty());
+    assertFalse("Test setup should leave pages resident in the pool", before.isEmpty());
+    /*
+     * The set comparison below is only valid while the pool stays under-filled:
+     * with no eviction the live snapshot equals what recordBufferInventory
+     * persists at shutdown, and an unlocked buffer copy is stable. Fail loudly
+     * if a future dataset change fills the pool and invalidates that.
+     */
+    assertTrue("Pool must stay under-filled for this comparison to be meaningful",
+        before.size() < pool.getBufferCount());
 
-    ex = null;
     _persistit.close();
 
     _persistit = new Persistit(_config);
-    pool = _persistit.getVolume("persistit").getStructure().getPool();
+    pool = _persistit.getVolume(VOLUME_NAME).getStructure().getPool();
 
+    /*
+     * One-way invariant (before is a subset of after): warmup must reload every
+     * page that was resident at shutdown. Slot position is intentionally not
+     * asserted (it is not preserved), and after may legitimately hold extra
+     * pages, so this deliberately drops the old bidirectional per-slot check.
+     */
     final Set<String> after = residentPages(pool);
     final Set<String> missing = new HashSet<String>(before);
     missing.removeAll(after);
@@ -71,10 +88,13 @@ public class WarmupTest extends PersistitUnitTestCase {
   }
 
   /**
-   * Collects an identity ({@code volume:page:type:size}) for every valid,
-   * recordable buffer currently resident in the pool. Mirrors the filtering in
-   * {@link BufferPool#recordBufferInventory}, which skips temporary and lock
-   * volumes, so the returned set is exactly what warmup is expected to reload.
+   * Identity ({@code volume:page:type}) of every valid, recordable buffer
+   * resident in the pool, applying the same volume filter as
+   * {@link BufferPool#recordBufferInventory} (temporary and lock volumes are
+   * skipped) so the set is exactly what warmup is expected to reload. The pool
+   * is under-filled and quiescent at both call sites, so an unlocked
+   * {@link BufferPool#getBufferCopy(int)} is stable here and the torn-read spin
+   * guard that recordBufferInventory needs is unnecessary.
    */
   private static Set<String> residentPages(final BufferPool pool) {
     final Set<String> pages = new HashSet<String>();
@@ -82,8 +102,7 @@ public class WarmupTest extends PersistitUnitTestCase {
       final Buffer b = pool.getBufferCopy(i);
       final Volume volume = b.getVolume();
       if (b.isValid() && volume != null && !volume.isTemporary() && !volume.isLockVolume()) {
-        pages.add(volume.getName() + ':' + b.getPageAddress() + ':' + b.getPageType() + ':'
-            + b.getBufferSize());
+        pages.add(volume.getName() + ':' + b.getPageAddress() + ':' + b.getPageType());
       }
     }
     return pages;

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -20,9 +20,10 @@ package com.persistit;
 
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class WarmupTest extends PersistitUnitTestCase {
@@ -44,24 +45,48 @@ public class WarmupTest extends PersistitUnitTestCase {
       ex.clear().append(i).store();
     }
 
-    final Buffer[] buff = new Buffer[100];
-    for (int i = 0; i < pool.getBufferCount(); ++i) {
-      buff[i] = pool.getBufferCopy(i);
-    }
+    /*
+     * Warmup (bufferinventory + bufferpreload) guarantees that the pages
+     * resident in the pool at shutdown are read back into the pool on restart.
+     * It does not guarantee that a page returns to the same buffer slot:
+     * preloadBufferInventory() sorts the recorded pages by read order and
+     * reallocates buffers via the clock algorithm, so the slot index is not
+     * preserved. Compare the set of resident pages, not per-slot correspondence
+     * (the latter only happened to match and made the test flaky).
+     */
+    final Set<String> before = residentPages(pool);
+    assertTrue("Test setup should leave pages resident in the pool", !before.isEmpty());
 
     ex = null;
     _persistit.close();
 
     _persistit = new Persistit(_config);
-    ex = _persistit.getExchange("persistit", "WarmupTest", false);
-    pool = ex.getBufferPool();
+    pool = _persistit.getVolume("persistit").getStructure().getPool();
 
-    for (int i = 0; i < pool.getBufferCount(); ++i) {
-      final Buffer bufferCopy = pool.getBufferCopy(i);
-      assertEquals(bufferCopy.getPageAddress(), buff[i].getPageAddress());
-      assertEquals(bufferCopy.getPageType(), buff[i].getPageType());
-      assertEquals(bufferCopy.getBufferSize(), buff[i].getBufferSize());
+    final Set<String> after = residentPages(pool);
+    final Set<String> missing = new HashSet<String>(before);
+    missing.removeAll(after);
+    assertTrue("Warmup should preload every previously-resident page; missing=" + missing,
+        missing.isEmpty());
+  }
+
+  /**
+   * Collects an identity ({@code volume:page:type:size}) for every valid,
+   * recordable buffer currently resident in the pool. Mirrors the filtering in
+   * {@link BufferPool#recordBufferInventory}, which skips temporary and lock
+   * volumes, so the returned set is exactly what warmup is expected to reload.
+   */
+  private static Set<String> residentPages(final BufferPool pool) {
+    final Set<String> pages = new HashSet<String>();
+    for (int i = 0; i < pool.getBufferCount(); i++) {
+      final Buffer b = pool.getBufferCopy(i);
+      final Volume volume = b.getVolume();
+      if (b.isValid() && volume != null && !volume.isTemporary() && !volume.isLockVolume()) {
+        pages.add(volume.getName() + ':' + b.getPageAddress() + ':' + b.getPageType() + ':'
+            + b.getBufferSize());
+      }
     }
+    return pages;
   }
 
   @Test

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -39,6 +39,13 @@ public class WarmupTest extends PersistitUnitTestCase {
 
   @Test
   public void testWarmup() throws Exception {
+    /*
+     * Disable background cleanup/pruning on both the pre-shutdown and the
+     * post-restart instance so the pool is not mutated concurrently while
+     * residentPages() takes its unsynchronized getBufferCopy() snapshots.
+     */
+    disableBackgroundCleanup();
+
     Exchange ex = _persistit.getExchange("persistit", "WarmupTest", true);
     BufferPool pool = ex.getBufferPool();
     for (int i = 1; i <= 1000; i++) {
@@ -51,28 +58,31 @@ public class WarmupTest extends PersistitUnitTestCase {
      * resident in the pool at shutdown are read back into the pool on restart.
      * It does not guarantee that a page returns to the same buffer slot:
      * preloadBufferInventory() sorts the recorded pages by read order and
-     * reallocates buffers via the clock algorithm, so the slot index is not
-     * preserved. The old per-slot assertion depended on the exact interleaving
-     * of the preload order and background eviction/cleanup between shutdown and
-     * the snapshot, which is why it passed on most JVMs but failed on the JDK 17
-     * runner (expected:<0> but was:<2> -- an empty slot where the page was still
-     * resident, just relocated). Compare the set of resident pages instead.
+     * reallocates buffers via the clock algorithm, so the slot index depends on
+     * timing in both runs. The old per-slot assertion (expected:<0> but was:<2>
+     * -- an empty slot where the page was resident, just relocated) only matched
+     * by coincidence; warmup provides no slot-stability property. Compare the
+     * set of resident pages instead.
      */
     final Set<String> before = residentPages(pool);
     assertFalse("Test setup should leave pages resident in the pool", before.isEmpty());
     /*
-     * The set comparison below is only valid while the pool stays under-filled:
-     * with no eviction the live snapshot equals what recordBufferInventory
-     * persists at shutdown, and an unlocked buffer copy is stable. Fail loudly
-     * if a future dataset change fills the pool and invalidates that.
+     * The subset comparison below is only meaningful while the pool stays
+     * under-filled: while free buffers remain the pool never evicts, so a
+     * buffer's (volume, page) identity does not change under it and the
+     * unsynchronized getBufferCopy() reads in residentPages() cannot tear. Fail
+     * loudly if a future dataset change fills the pool.
      */
     assertTrue("Pool must stay under-filled for this comparison to be meaningful",
-        before.size() < pool.getBufferCount());
+        validPageCount(pool) < pool.getBufferCount());
 
     _persistit.close();
 
     _persistit = new Persistit(_config);
+    disableBackgroundCleanup();
     pool = _persistit.getVolume(VOLUME_NAME).getStructure().getPool();
+    assertTrue("Restarted pool must also stay under-filled for the comparison",
+        validPageCount(pool) < pool.getBufferCount());
 
     /*
      * One-way invariant (before is a subset of after): warmup must reload every
@@ -91,10 +101,11 @@ public class WarmupTest extends PersistitUnitTestCase {
    * Identity ({@code volume:page:type}) of every valid, recordable buffer
    * resident in the pool, applying the same volume filter as
    * {@link BufferPool#recordBufferInventory} (temporary and lock volumes are
-   * skipped) so the set is exactly what warmup is expected to reload. The pool
-   * is under-filled and quiescent at both call sites, so an unlocked
-   * {@link BufferPool#getBufferCopy(int)} is stable here and the torn-read spin
-   * guard that recordBufferInventory needs is unnecessary.
+   * skipped) so the set is exactly what warmup is expected to reload. Callers
+   * disable background cleanup and assert the pool is under-filled, so no
+   * eviction reallocates a buffer while it is read; a buffer's identity is
+   * therefore stable and the unlocked {@link BufferPool#getBufferCopy(int)}
+   * needs no torn-read spin guard.
    */
   private static Set<String> residentPages(final BufferPool pool) {
     final Set<String> pages = new HashSet<String>();
@@ -106,6 +117,22 @@ public class WarmupTest extends PersistitUnitTestCase {
       }
     }
     return pages;
+  }
+
+  /**
+   * Number of buffers currently holding a page. The pool is full (and starts
+   * evicting) once this reaches {@link BufferPool#getBufferCount()}; counting
+   * valid buffers directly keeps the under-fill guard independent of the
+   * filtered/deduplicated {@link #residentPages} set.
+   */
+  private static int validPageCount(final BufferPool pool) {
+    int count = 0;
+    for (int i = 0; i < pool.getBufferCount(); i++) {
+      if (pool.getBufferCopy(i).isValid()) {
+        count++;
+      }
+    }
+    return count;
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes a flaky failure in `com.persistit.WarmupTest.testWarmup` (persistit/core) seen on `build-maven (ubuntu-latest, 17)`.

## Root cause

`testWarmup` restarts Persistit with `bufferinventory` + `bufferpreload` and asserted a **per-slot** correspondence — that `pool.getBufferCopy(i)` after the restart holds the same page as before shutdown:

```java
assertEquals(bufferCopy.getPageAddress(), buff[i].getPageAddress());
```

That is not what warmup guarantees. `BufferPool.preloadBufferInventory()` reads the recorded pages back, **sorts them by read order** (`PageNode.READ_COMPARATOR`) and reallocates buffers via the clock algorithm, so a page is reloaded into the pool but **not necessarily into its original slot index**. Slot assignment is timing-dependent in *both* runs (background threads + reallocation order), so the per-slot equality only matched by coincidence — the JDK 17 runner was incidental (`expected:<0> but was:<2>`: an empty slot where the original held page 2, the page still resident, just relocated).

## Fix

Assert the invariant warmup actually provides — every valid, recordable page resident at shutdown is resident again after the restart (a one-way `before ⊆ after` subset), comparing the **set** of pages (`volume:page:type`), not their slot positions. The filter mirrors `BufferPool.recordBufferInventory` (skips temporary and lock volumes).

Making the set snapshots safe (round-2 review):

- `residentPages()` reads `getBufferCopy(i)` without `recordBufferInventory`'s torn-read spin guard. Call `disableBackgroundCleanup()` on **both** the pre-shutdown and post-restart instances, and assert each pool is **under-filled** (`validPageCount() < getBufferCount()`): with cleanup off and free buffers available the pool never evicts, so a buffer's `(volume, page)` identity is stable and the unsynchronized reads cannot tear.
- The under-fill guard counts occupied buffers directly, independent of the filtered/deduplicated resident set.

A genuine failure to preload a page is still caught (`missing=` names it).

## Testing

`mvn -o -pl persistit/core test -Dtest=WarmupTest` — `Tests run: 2, Failures: 0`; `testWarmup` green across repeated consecutive runs (a 50-run loop was used to confirm stability). The original JDK-17 flake does not reproduce locally on macOS; the fix rests on the slot-identity argument established by code reading (preload reorders and reallocates buffers by construction).
