### PR TITLE
Stabilize flaky TransactionTest2.transactionsConcurrentWithPersistitClose

### DIFF
--- a/persistit/core/src/test/java/com/persistit/TransactionTest2.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionTest2.java
@@ -246,28 +246,38 @@ public class TransactionTest2 extends PersistitUnitTestCase {
 
     @Test
     public void transactionsConcurrentWithPersistitClose() throws Exception {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                final Thread[] threadArray = new Thread[_threadCount];
-                for (int index = 0; index < _threadCount; index++) {
-                    threadArray[index] = new Thread(new Runnable() {
-                        @Override
-                        public void run() {
-                            runIt(Integer.MAX_VALUE);
-                        }
-                    }, "TransactionThread_" + index);
+        _strandedThreads.set(0);
+        final Thread[] threadArray = new Thread[_threadCount];
+        for (int index = 0; index < _threadCount; index++) {
+            threadArray[index] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    runIt(Integer.MAX_VALUE);
                 }
-                for (int index = 0; index < _threadCount; index++) {
-                    threadArray[index].start();
-                }
-            }
-        }).start();
+            }, "TransactionThread_" + index);
+        }
+        for (int index = 0; index < _threadCount; index++) {
+            threadArray[index].start();
+        }
         /*
          * Let the threads crank up
          */
         Thread.sleep(1000);
         _persistit.close();
+        /*
+         * Closing Persistit makes the worker threads unwind by throwing one of
+         * the expected exceptions, but that unwinding is asynchronous. Give the
+         * threads a bounded amount of time to observe the closure and exit
+         * before checking that none were left stranded; otherwise a worker that
+         * has not yet caught its exception produces a spurious failure.
+         */
+        final long deadline = System.currentTimeMillis() + TIMEOUT;
+        for (final Thread thread : threadArray) {
+            final long remaining = deadline - System.currentTimeMillis();
+            if (remaining > 0) {
+                thread.join(remaining);
+            }
+        }
         assertEquals("All threads should have exited correctly", 0, _strandedThreads.get());
     }
 


### PR DESCRIPTION
## Problem

`TransactionTest2.transactionsConcurrentWithPersistitClose` is flaky. It starts worker threads that run transactions in a loop, closes Persistit, and then immediately asserts that no worker thread was left stranded:

```java
_persistit.close();
assertEquals("All threads should have exited correctly", 0, _strandedThreads.get());
```

Each worker increments `_strandedThreads` on entry and only decrements it once it catches one of the expected exceptions thrown when Persistit is closed. That unwinding is **asynchronous**: after `close()` returns, a worker still in the middle of a transaction needs a moment to reach its next Persistit operation, receive the exception, and decrement the counter. There is no wait between `close()` and the assertion, so on a loaded CI runner a worker that has not yet caught its exception leaves the counter at 1:

```
java.lang.AssertionError: All threads should have exited correctly expected:<0> but was:<1>
    at com.persistit.TransactionTest2.transactionsConcurrentWithPersistitClose(TransactionTest2.java:271)
```

Observed on `build-maven (ubuntu-latest, 17)`; the same module passed on JDK 11/21/25/26 in the same run, confirming it is a timing flake rather than a real regression.

## Fix

- Keep references to the worker threads and `join()` them with a single bounded deadline (`TIMEOUT`, 10s) before the assertion, so the threads get a chance to observe the closure and exit. On success the join returns almost immediately; on a genuine problem (a stuck worker, or one that exited via an unexpected path and therefore did not decrement the counter) the assertion still fails, so the test keeps its diagnostic value.
- Flatten the now-unnecessary launcher thread so the worker threads can be joined directly.
- Reset the shared static `_strandedThreads` counter at the start of the test for isolation from the other methods in the class.

## Verification

- `transactionsConcurrentWithPersistitClose` run 5×: 5/5 pass.
- Full `TransactionTest2` class: 5 tests, 0 failures.
