### PR TITLE
Stabilize flaky TransactionIndexTest.testDeadlockedWwDependency

### DIFF
--- a/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.persistit.TransactionStatus.ABORTED;
+import static com.persistit.TransactionStatus.TIMED_OUT;
 import static com.persistit.TransactionStatus.UNCOMMITTED;
 
 public class TransactionIndexTest extends TestCase {
@@ -251,42 +252,50 @@ public class TransactionIndexTest extends TestCase {
         final AtomicLong elapsed2 = new AtomicLong(-42);
         final AtomicLong elapsed3 = new AtomicLong(-42);
 
-        final Thread t1 = tryWwDependency(ti, ts1, ts2, 5000, result1, elapsed1);
+        final Thread t1 = tryWwDependency(ti, ts1, ts2, 1000000, result1, elapsed1);
         final Thread t2 = tryWwDependency(ti, ts2, ts3, 1000000, result2, elapsed2);
         Thread.sleep(1000);
         final Thread t3 = tryWwDependency(ti, ts3, ts1, 10000, result3, elapsed3);
 
+        /*
+         * The waiters form a cycle (ts1 -> ts3 -> ts2 -> ts1, "->" = waits for),
+         * closed when t3 starts. Detection is distributed: each waiter re-checks
+         * every SHORT_TIMEOUT and clears its own edge in a finally only after its
+         * result is decided, so any participant -- not just t3 -- may report the
+         * deadlock, and more than one may. Resolve the cycle by aborting each
+         * waiter's target in turn (ts1 is the transaction the deadlock tells to
+         * abort), which lets any waiter that did not detect the deadlock itself
+         * exit cleanly with 0 rather than time out.
+         */
         t3.join();
+        ts1.abort();
+        ti.notifyCompleted(ts1, ABORTED);
         t1.join();
         ts2.abort();
         ti.notifyCompleted(ts2, ABORTED);
         t2.join();
 
+        final String state = " (result1=" + result1 + ", result2=" + result2 + ", result3=" + result3
+                + ", elapsed1=" + elapsed1 + ", elapsed2=" + elapsed2 + ", elapsed3=" + elapsed3 + ")";
         /*
-         * The waiters form a cycle (ts1 -> ts3 -> ts2 -> ts1, "->" = waits for).
-         * Detection is distributed: each waiter re-checks every SHORT_TIMEOUT and
-         * clears its own edge between iterations, and the edge that reveals a
-         * cycle is nulled in a finally only after the result is decided, so any
-         * participant -- not just the one closing the cycle -- may report it. The
-         * cycle is live only between t3's start and t1's timeout, so at least one
-         * detection is highly likely but not strictly guaranteed under a long
+         * The cycle is live only from t3's start until the first waiter exits, so
+         * a detection is highly likely but not strictly guaranteed under a long
          * stall.
          */
-        final String state = " (result1=" + result1 + ", result2=" + result2
-                + ", result3=" + result3 + ", elapsed3=" + elapsed3 + ")";
         assertTrue("Deadlock not detected by any participant" + state,
-                result1.get() == UNCOMMITTED || result2.get() == UNCOMMITTED
-                        || result3.get() == UNCOMMITTED);
-        assertTrue("ts3 -> ts2 must either detect the deadlock or clear" + state,
-                result2.get() == 0 || result2.get() == UNCOMMITTED);
+                result1.get() == UNCOMMITTED || result2.get() == UNCOMMITTED || result3.get() == UNCOMMITTED);
         /*
-         * Once any waiter returns UNCOMMITTED its finally breaks the cycle for
-         * good, so if t3 detects the deadlock at all it must be prompt (otherwise
-         * it can no longer see the cycle and simply times out).
+         * t1 (ts2 -> ts1) and t2 (ts3 -> ts2) cannot time out (1000000 ms) and
+         * their targets abort, so each either detected the deadlock itself
+         * (UNCOMMITTED) or observed the abort (0). t3 (ts1 -> ts3) either detects
+         * the deadlock or, if it stalled past the cycle's lifetime, times out.
          */
-        if (result3.get() == UNCOMMITTED) {
-            assertTrue("deadlock detection must be prompt" + state, elapsed3.get() < 1000);
-        }
+        assertTrue("ts2 -> ts1 must detect the deadlock or clear" + state,
+                result1.get() == 0 || result1.get() == UNCOMMITTED);
+        assertTrue("ts3 -> ts2 must detect the deadlock or clear" + state,
+                result2.get() == 0 || result2.get() == UNCOMMITTED);
+        assertTrue("ts1 -> ts3 must detect the deadlock or time out" + state,
+                result3.get() == UNCOMMITTED || result3.get() == TIMED_OUT);
         assertTrue("t1 must block until the cycle forms" + state, elapsed1.get() >= 900);
         assertTrue("t2 must block until the cycle forms" + state, elapsed2.get() >= 900);
     }

--- a/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
@@ -1,8 +1,6 @@
 /**
  * Copyright 2011-2012 Akiban Technologies, Inc.
- *
- * Portions Copyrighted 2026 3A Systems, LLC.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -252,7 +251,7 @@ public class TransactionIndexTest extends TestCase {
         final AtomicLong elapsed2 = new AtomicLong(-42);
         final AtomicLong elapsed3 = new AtomicLong(-42);
 
-        final Thread t1 = tryWwDependency(ti, ts1, ts2, 2000, result1, elapsed1);
+        final Thread t1 = tryWwDependency(ti, ts1, ts2, 5000, result1, elapsed1);
         final Thread t2 = tryWwDependency(ti, ts2, ts3, 1000000, result2, elapsed2);
         Thread.sleep(1000);
         final Thread t3 = tryWwDependency(ti, ts3, ts1, 10000, result3, elapsed3);
@@ -260,33 +259,36 @@ public class TransactionIndexTest extends TestCase {
         t3.join();
         t1.join();
         ts2.abort();
-        ti.notifyCompleted(ts2, TransactionStatus.ABORTED);
+        ti.notifyCompleted(ts2, ABORTED);
         t2.join();
 
         /*
-         * The three transactions form a dependency cycle
-         * (ts1 <- ts3 <- ts2 <- ts1), so the deadlock must be detected. Deadlock
-         * detection is distributed: every waiting thread re-checks for a cycle
-         * roughly every SHORT_TIMEOUT (10 ms), so any transaction on the cycle --
-         * not only the one that closes it -- may report the deadlock, and more
-         * than one may do so within the brief window before the cycle is broken.
-         * Pinning the outcome to a specific thread made this test flaky under
-         * load (observed on ubuntu-latest JDK 17: t2 detected the deadlock before
-         * ts2 was aborted, so result2 was UNCOMMITTED instead of 0). Assert the
-         * invariants that always hold instead:
-         *
-         *   - the deadlock is detected by at least one participant (UNCOMMITTED);
-         *   - ts3's wait on ts2 ends either by detecting the deadlock or by
-         *     observing ts2's abort (0);
-         *   - each waiter blocks until the cycle forms (~1000 ms) before
-         *     returning.
+         * The waiters form a cycle (ts1 -> ts3 -> ts2 -> ts1, "->" = waits for).
+         * Detection is distributed: each waiter re-checks every SHORT_TIMEOUT and
+         * clears its own edge between iterations, and the edge that reveals a
+         * cycle is nulled in a finally only after the result is decided, so any
+         * participant -- not just the one closing the cycle -- may report it. The
+         * cycle is live only between t3's start and t1's timeout, so at least one
+         * detection is highly likely but not strictly guaranteed under a long
+         * stall.
          */
-        assertTrue("Deadlock not detected", result1.get() == UNCOMMITTED
-                || result2.get() == UNCOMMITTED || result3.get() == UNCOMMITTED);
-        assertTrue("ts3->ts2 must either clear or detect the deadlock",
+        final String state = " (result1=" + result1 + ", result2=" + result2
+                + ", result3=" + result3 + ", elapsed3=" + elapsed3 + ")";
+        assertTrue("Deadlock not detected by any participant" + state,
+                result1.get() == UNCOMMITTED || result2.get() == UNCOMMITTED
+                        || result3.get() == UNCOMMITTED);
+        assertTrue("ts3 -> ts2 must either detect the deadlock or clear" + state,
                 result2.get() == 0 || result2.get() == UNCOMMITTED);
-        assertTrue(elapsed1.get() >= 900);
-        assertTrue(elapsed2.get() >= 900);
+        /*
+         * Once any waiter returns UNCOMMITTED its finally breaks the cycle for
+         * good, so if t3 detects the deadlock at all it must be prompt (otherwise
+         * it can no longer see the cycle and simply times out).
+         */
+        if (result3.get() == UNCOMMITTED) {
+            assertTrue("deadlock detection must be prompt" + state, elapsed3.get() < 1000);
+        }
+        assertTrue("t1 must block until the cycle forms" + state, elapsed1.get() >= 900);
+        assertTrue("t2 must block until the cycle forms" + state, elapsed2.get() >= 900);
     }
 
     @Test

--- a/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionIndexTest.java
@@ -1,6 +1,8 @@
 /**
  * Copyright 2011-2012 Akiban Technologies, Inc.
- * 
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -256,17 +258,35 @@ public class TransactionIndexTest extends TestCase {
         final Thread t3 = tryWwDependency(ti, ts3, ts1, 10000, result3, elapsed3);
 
         t3.join();
-        assertEquals("Deadlock not detected", TransactionStatus.UNCOMMITTED, result3.get());
-
         t1.join();
         ts2.abort();
         ti.notifyCompleted(ts2, TransactionStatus.ABORTED);
-
         t2.join();
-        assertEquals(0, result2.get());
+
+        /*
+         * The three transactions form a dependency cycle
+         * (ts1 <- ts3 <- ts2 <- ts1), so the deadlock must be detected. Deadlock
+         * detection is distributed: every waiting thread re-checks for a cycle
+         * roughly every SHORT_TIMEOUT (10 ms), so any transaction on the cycle --
+         * not only the one that closes it -- may report the deadlock, and more
+         * than one may do so within the brief window before the cycle is broken.
+         * Pinning the outcome to a specific thread made this test flaky under
+         * load (observed on ubuntu-latest JDK 17: t2 detected the deadlock before
+         * ts2 was aborted, so result2 was UNCOMMITTED instead of 0). Assert the
+         * invariants that always hold instead:
+         *
+         *   - the deadlock is detected by at least one participant (UNCOMMITTED);
+         *   - ts3's wait on ts2 ends either by detecting the deadlock or by
+         *     observing ts2's abort (0);
+         *   - each waiter blocks until the cycle forms (~1000 ms) before
+         *     returning.
+         */
+        assertTrue("Deadlock not detected", result1.get() == UNCOMMITTED
+                || result2.get() == UNCOMMITTED || result3.get() == UNCOMMITTED);
+        assertTrue("ts3->ts2 must either clear or detect the deadlock",
+                result2.get() == 0 || result2.get() == UNCOMMITTED);
         assertTrue(elapsed1.get() >= 900);
         assertTrue(elapsed2.get() >= 900);
-        assertTrue(elapsed3.get() < 1000);
     }
 
     @Test


### PR DESCRIPTION
## Problem

`TransactionIndexTest.testDeadlockedWwDependency` is flaky. It builds a three-transaction deadlock cycle (`ts1 -> ts3 -> ts2 -> ts1`, `->` = "waits for") and asserted a specific thread would win the deadlock-detection race:

```java
t3.join();
assertEquals("Deadlock not detected", UNCOMMITTED, result3.get()); // assumes t3 detects
...
assertEquals(0, result2.get());                                    // assumes t2 clears, not detects
```

Deadlock detection is **distributed**: in `TransactionIndex.wwDependency` each waiter calls `source.setDepends(target)` then `isDeadlocked(source)` every `SHORT_TIMEOUT`, and the edge that reveals a cycle is nulled in a `finally` only *after* the return value is decided. So any transaction on the cycle — not just the one that closes it — may return `UNCOMMITTED`, and more than one can. Under load a second waiter detected the deadlock before its target was aborted, so its result was `UNCOMMITTED` instead of `0`:

```
junit.framework.AssertionFailedError: expected:<0> but was:<9223372036854775807>   (UNCOMMITTED)
```

Observed on `build-maven (ubuntu-latest, 17)`.

## Fix

Stop pinning the outcome to a particular thread, and resolve the cycle the way the deadlock dictates:

- **Resolve by aborting each waiter's target**, starting with `ts1` — the transaction the deadlock tells to abort. This unblocks `t1` at ~1 s instead of forcing it to time out, so both waiter timeouts stay at 1 000 000 ms, runtime is ~1 s (no bimodal 1 s/5 s), and the detection window widens to `t3`'s own 10 s timeout.
- **Assert value domains** rather than exact per-thread outcomes:
  - a deadlock is detected by at least one participant (`result1 | result2 | result3 == UNCOMMITTED`) — highly likely, though the comment notes it is not strictly guaranteed under a long stall (the cycle is only live from `t3`'s start until the first waiter exits);
  - `t1`/`t2` cannot time out and their targets abort, so `result1, result2 ∈ {0, UNCOMMITTED}`;
  - `t3` either detects the deadlock or, if it stalled past the cycle's lifetime, times out: `result3 ∈ {UNCOMMITTED, TIMED_OUT}`;
  - each waiter blocks until the cycle forms (`elapsed1, elapsed2 >= 900`).
- Failure messages carry a `state` string with all `result*`/`elapsed*` values for diagnosability.

No detection-latency (`elapsed3 < 1000`) guard: with a real detection window that can legitimately span several seconds, such a bound constrains the scheduler, not the product. A bogus positive commit timestamp or a spurious `0` from `t3` still fails the domain assertions.

## Verification

- `testDeadlockedWwDependency` run 10×: 10/10 pass, ~1.05–1.13 s each (the restructure removes the bimodal runtime; `t3` detects promptly).
- Full `TransactionIndexTest` class: 8 tests, 0 failures.
