### PR TITLE
Fix bug-1017957 class race in fixIndexHole; stabilize TreeTransactionalLifetimeTest and WarmupTest

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -4076,12 +4076,49 @@ public class Exchange implements ReadOnlyExchange {
       return false;
     }
     try {
+      /*
+       * This action was enqueued by rebalanceSplit() when the page was
+       * reachable only through its sibling chain, and may be arbitrarily
+       * stale by the time the background CleanupManager runs it: a covering
+       * removeKeyRange may since have unlinked the page onto a garbage chain
+       * (leaving its content and type intact, or retyping it PAGE_TYPE_GARBAGE
+       * if it became a chain root), or the page may have been reused by an
+       * unrelated allocation. Blindly inserting a key-pointer pair for such a
+       * page plants a dangling index entry to a garbage or reused page -- the
+       * bug 1017957 failure mode, observed as transient
+       * CorruptVolumeExceptions ("invalid page type 30") under concurrent
+       * structural stress. Structure deletes hold the tree writer claim, so
+       * under the reader claim held here the page's reachability cannot
+       * change; validate it before inserting the pointer.
+       */
       buffer = _pool.get(_volume, page, false, true);
+      if (buffer.getPageType() != level + PAGE_TYPE_DATA
+        || buffer.getKeyBlockEnd() <= buffer.getKeyBlockStart()) {
+        // Retyped (garbage-chain root or reused elsewhere) or empty: the
+        // index hole this action was created for no longer exists.
+        return true;
+      }
       buffer.nextKey(_spareKey2, buffer.toKeyBlock(0));
       _value.setPointerValue(page);
       _value.setPointerPageType(buffer.getPageType());
       buffer.release();
       buffer = null;
+      /*
+       * A page sitting on a garbage chain keeps its old type and content, so
+       * the type check above is not sufficient. Verify the page is still
+       * reachable in this tree: a search for its current first key at this
+       * level must land on the page itself (via the B-link right-walk, since
+       * the hole means it has no parent entry yet). If the search lands
+       * elsewhere the action is stale and inserting the pointer would corrupt
+       * the index, so drop it.
+       */
+      searchTree(_spareKey2, level, false);
+      final LevelCache lc = _levelCache[level];
+      final long landedOn = lc._page;
+      lc._buffer.releaseTouched();
+      if (landedOn != page) {
+        return true;
+      }
       storeInternal(_spareKey2, _value, level + 1, StoreOptions.NONE);
       return true;
     } finally {

--- a/persistit/core/src/test/java/com/persistit/Bug1017957Test.java
+++ b/persistit/core/src/test/java/com/persistit/Bug1017957Test.java
@@ -1,6 +1,8 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
- * 
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +18,7 @@
 
 package com.persistit;
 
+import com.persistit.exception.CorruptVolumeException;
 import org.junit.Test;
 
 import java.io.PrintWriter;
@@ -112,6 +115,7 @@ public class Bug1017957Test extends PersistitUnitTestCase {
   public void induceCorruptionByStress() throws Exception {
     final long expiresAt = System.nanoTime() + STRESS_NANOS;
     final AtomicInteger totalErrors = new AtomicInteger();
+    final AtomicInteger unexpectedErrors = new AtomicInteger();
     final Thread t1 = new Thread(new Runnable() {
       @Override
       public void run() {
@@ -131,6 +135,15 @@ public class Bug1017957Test extends PersistitUnitTestCase {
                 e.printStackTrace();
               }
               totalErrors.incrementAndGet();
+              // A CorruptVolumeException here is a transient read of a page that
+              // the other thread is concurrently splitting/joining (this test
+              // does non-transactional structural stress). It does not imply
+              // persistent corruption -- that is verified separately by the
+              // final IntegrityCheck. Only other exception types count as an
+              // unexpected failure of the bug-1017957 fix.
+              if (!(e instanceof CorruptVolumeException)) {
+                unexpectedErrors.incrementAndGet();
+              }
             }
           }
         } catch (final Exception e) {
@@ -158,6 +171,15 @@ public class Bug1017957Test extends PersistitUnitTestCase {
                 e.printStackTrace();
               }
               totalErrors.incrementAndGet();
+              // A CorruptVolumeException here is a transient read of a page that
+              // the other thread is concurrently splitting/joining (this test
+              // does non-transactional structural stress). It does not imply
+              // persistent corruption -- that is verified separately by the
+              // final IntegrityCheck. Only other exception types count as an
+              // unexpected failure of the bug-1017957 fix.
+              if (!(e instanceof CorruptVolumeException)) {
+                unexpectedErrors.incrementAndGet();
+              }
             }
           }
         } catch (final Exception e) {
@@ -177,9 +199,25 @@ public class Bug1017957Test extends PersistitUnitTestCase {
     icheck.setMessageLogVerbosity(Task.LOG_VERBOSE);
     icheck.setMessageWriter(new PrintWriter(System.out));
     icheck.checkVolume(_persistit.getVolume("persistit"));
-    System.out.printf("\nTotal errors %d", totalErrors.get());
+    System.out.printf("%nTotal errors %d (unexpected %d)%n", totalErrors.get(), unexpectedErrors.get());
+    /*
+     * The regression this test guards against (bug 1017957) manifests as
+     * *persistent* volume corruption -- a dangling index pointer to a reused
+     * garbage page, or a stale LevelCache after an unbumped tree generation.
+     * The authoritative assertion is therefore that the volume passes the
+     * IntegrityCheck with no faults after the concurrent stress run.
+     */
     assertEquals("Corrupt volume", 0, icheck.getFaults().length);
-    assertEquals("Exception occurred", 0, totalErrors.get());
+    /*
+     * The two worker threads mutate the same tree concurrently without
+     * transactions, so a traversal can transiently observe a page that another
+     * thread is in the middle of splitting/joining and defensively raise a
+     * CorruptVolumeException. On fast JVMs this happens occasionally even
+     * though the volume ends up structurally sound (asserted above), so those
+     * transient exceptions are counted and printed for diagnostics but are not
+     * treated as failures. Any other exception type still fails the test.
+     */
+    assertEquals("Unexpected exception occurred", 0, unexpectedErrors.get());
   }
 
   /**

--- a/persistit/core/src/test/java/com/persistit/Bug1017957Test.java
+++ b/persistit/core/src/test/java/com/persistit/Bug1017957Test.java
@@ -1,8 +1,6 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
- *
- * Portions Copyrighted 2026 3A Systems, LLC.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,7 +16,6 @@
 
 package com.persistit;
 
-import com.persistit.exception.CorruptVolumeException;
 import org.junit.Test;
 
 import java.io.PrintWriter;
@@ -115,7 +112,6 @@ public class Bug1017957Test extends PersistitUnitTestCase {
   public void induceCorruptionByStress() throws Exception {
     final long expiresAt = System.nanoTime() + STRESS_NANOS;
     final AtomicInteger totalErrors = new AtomicInteger();
-    final AtomicInteger unexpectedErrors = new AtomicInteger();
     final Thread t1 = new Thread(new Runnable() {
       @Override
       public void run() {
@@ -135,15 +131,6 @@ public class Bug1017957Test extends PersistitUnitTestCase {
                 e.printStackTrace();
               }
               totalErrors.incrementAndGet();
-              // A CorruptVolumeException here is a transient read of a page that
-              // the other thread is concurrently splitting/joining (this test
-              // does non-transactional structural stress). It does not imply
-              // persistent corruption -- that is verified separately by the
-              // final IntegrityCheck. Only other exception types count as an
-              // unexpected failure of the bug-1017957 fix.
-              if (!(e instanceof CorruptVolumeException)) {
-                unexpectedErrors.incrementAndGet();
-              }
             }
           }
         } catch (final Exception e) {
@@ -171,15 +158,6 @@ public class Bug1017957Test extends PersistitUnitTestCase {
                 e.printStackTrace();
               }
               totalErrors.incrementAndGet();
-              // A CorruptVolumeException here is a transient read of a page that
-              // the other thread is concurrently splitting/joining (this test
-              // does non-transactional structural stress). It does not imply
-              // persistent corruption -- that is verified separately by the
-              // final IntegrityCheck. Only other exception types count as an
-              // unexpected failure of the bug-1017957 fix.
-              if (!(e instanceof CorruptVolumeException)) {
-                unexpectedErrors.incrementAndGet();
-              }
             }
           }
         } catch (final Exception e) {
@@ -199,25 +177,9 @@ public class Bug1017957Test extends PersistitUnitTestCase {
     icheck.setMessageLogVerbosity(Task.LOG_VERBOSE);
     icheck.setMessageWriter(new PrintWriter(System.out));
     icheck.checkVolume(_persistit.getVolume("persistit"));
-    System.out.printf("%nTotal errors %d (unexpected %d)%n", totalErrors.get(), unexpectedErrors.get());
-    /*
-     * The regression this test guards against (bug 1017957) manifests as
-     * *persistent* volume corruption -- a dangling index pointer to a reused
-     * garbage page, or a stale LevelCache after an unbumped tree generation.
-     * The authoritative assertion is therefore that the volume passes the
-     * IntegrityCheck with no faults after the concurrent stress run.
-     */
+    System.out.printf("\nTotal errors %d", totalErrors.get());
     assertEquals("Corrupt volume", 0, icheck.getFaults().length);
-    /*
-     * The two worker threads mutate the same tree concurrently without
-     * transactions, so a traversal can transiently observe a page that another
-     * thread is in the middle of splitting/joining and defensively raise a
-     * CorruptVolumeException. On fast JVMs this happens occasionally even
-     * though the volume ends up structurally sound (asserted above), so those
-     * transient exceptions are counted and printed for diagnostics but are not
-     * treated as failures. Any other exception type still fails the test.
-     */
-    assertEquals("Unexpected exception occurred", 0, unexpectedErrors.get());
+    assertEquals("Exception occurred", 0, totalErrors.get());
   }
 
   /**

--- a/persistit/core/src/test/java/com/persistit/TrackingFileChannel.java
+++ b/persistit/core/src/test/java/com/persistit/TrackingFileChannel.java
@@ -163,13 +163,14 @@ class TrackingFileChannel extends FileChannel implements TestChannelInjector {
 
     public void assertOrdered(final boolean read, final boolean forward) {
         final List<Long> list = read ? _readPositions : _writePositions;
-        final long previous = forward ? -1 : Long.MAX_VALUE;
+        long previous = forward ? -1 : Long.MAX_VALUE;
         for (final Long position : list) {
             if (forward) {
                 assertTrue("Position should be larger", position > previous);
             } else {
                 assertTrue("Position should be smaller", position < previous);
             }
+            previous = position;
         }
     }
 }

--- a/persistit/core/src/test/java/com/persistit/TreeTransactionalLifetimeTest.java
+++ b/persistit/core/src/test/java/com/persistit/TreeTransactionalLifetimeTest.java
@@ -1,6 +1,8 @@
 /**
  * Copyright 2013 Akiban Technologies, Inc.
- * 
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -235,6 +237,19 @@ public class TreeTransactionalLifetimeTest extends PersistitUnitTestCase {
         if (crash || restart) {
             _persistit = new Persistit(_config);
             _persistit.initialize();
+            /*
+             * Recovery and the pruning of timely tree resources run
+             * asynchronously after initialize(). If the next helper iteration
+             * starts a transaction before that settles, residual tree-version
+             * state from this iteration's crash/restart can leak into its
+             * step-based MVCC visibility -- e.g. a tree created at step 1 shows
+             * up at step 0 -- producing an intermittent ComparisonFailure
+             * ("expected:<0[]...> but was:<0[:]...>") seen on CI. Settle the
+             * active-transaction cache and prune timely resources here, the same
+             * way the sibling tests quiesce MVCC state before asserting.
+             */
+            _persistit.getTransactionIndex().updateActiveTransactionCache();
+            _persistit.pruneTimelyResources();
         }
         assertEquals("Expected contents at steps", expected2, computeCreateRemoveState(treeName, 1));
     }

--- a/persistit/core/src/test/java/com/persistit/TreeTransactionalLifetimeTest.java
+++ b/persistit/core/src/test/java/com/persistit/TreeTransactionalLifetimeTest.java
@@ -238,15 +238,17 @@ public class TreeTransactionalLifetimeTest extends PersistitUnitTestCase {
             _persistit = new Persistit(_config);
             _persistit.initialize();
             /*
-             * Recovery and the pruning of timely tree resources run
-             * asynchronously after initialize(). If the next helper iteration
-             * starts a transaction before that settles, residual tree-version
-             * state from this iteration's crash/restart can leak into its
-             * step-based MVCC visibility -- e.g. a tree created at step 1 shows
-             * up at step 0 -- producing an intermittent ComparisonFailure
-             * ("expected:<0[]...> but was:<0[:]...>") seen on CI. Settle the
-             * active-transaction cache and prune timely resources here, the same
-             * way the sibling tests quiesce MVCC state before asserting.
+             * Recovery itself completes synchronously inside initialize(), but
+             * two maintenance tasks are asynchronous after it: the
+             * TransactionIndex's active-transaction-cache updater thread and
+             * the CleanupManager's timer-driven pruneTimelyResources(). If the
+             * next helper iteration starts a transaction before those settle,
+             * residual tree-version state from this iteration's crash/restart
+             * can leak into its step-based MVCC visibility -- e.g. a tree
+             * created at step 1 shows up at step 0 -- producing an intermittent
+             * ComparisonFailure ("expected:<0[]...> but was:<0[:]...>") seen on
+             * CI. Force both here, the same way the sibling tests quiesce MVCC
+             * state before asserting.
              */
             _persistit.getTransactionIndex().updateActiveTransactionCache();
             _persistit.pruneTimelyResources();

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -66,6 +66,21 @@ public class WarmupTest extends PersistitUnitTestCase {
 
   @Test
   public void readOrderIsSequential() throws Exception {
+    /*
+     * Stop background cleanup/pruning for this session so the buffer-pool state
+     * is deterministic. The assertion below requires that the pages recorded by
+     * the buffer inventory at shutdown are actually read back from the *volume*
+     * file (the injected TrackingFileChannel only sees volume reads). That holds
+     * only once copyBackPages() has fully drained the journal into the volume.
+     * When the background CLEANUP_MANAGER / page-writer / checkpoint activity
+     * races with copyBackPages(), the drain can be left incomplete, so on
+     * restart some recorded pages are served from the journal instead of the
+     * volume and TrackingFileChannel records zero reads -- an intermittent
+     * failure that reproduces on the CI Windows runner but not on Linux/macOS.
+     * This is the same background-eviction/cleanup interleaving that made the
+     * sibling testWarmup flaky. Disabling it makes the drain deterministic.
+     */
+    disableBackgroundCleanup();
 
     Exchange ex = _persistit.getExchange("persistit", "WarmupTest", true);
     BufferPool pool = ex.getBufferPool();

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -106,27 +106,39 @@ public class WarmupTest extends PersistitUnitTestCase {
     _persistit.copyBackPages();
     _persistit.close();
 
-    _persistit = new Persistit();
+    /*
+     * recordBufferInventory() at the close above interleaves its own tree stores
+     * with the buffer scan, so some recorded pages are the inventory tree's own
+     * pages; the closing checkpoint flushes those to the journal with no
+     * copyBack(), and on restart they would be served from the journal
+     * (VolumeStorageV2.readPage consults readPageFromJournal first), bypassing
+     * the injected volume channel. Reopen with inventory recording disabled,
+     * drain the journal into the volume, and close again so every recorded page
+     * lives in the volume file; the preload below then reads them through the
+     * tracked channel deterministically instead of racing the journal.
+     */
     _config.setBufferInventoryEnabled(false);
     _config.setBufferPreloadEnabled(false);
-    _persistit.setConfiguration(_config);
-    _persistit.initialize();
+    _persistit = new Persistit(_config);
+    _persistit.copyBackPages();
+    _persistit.close();
+
+    _persistit = new Persistit(_config);
 
     final Volume volume = _persistit.getVolume("persistit");
+    final MediatedFileChannel mfc = (MediatedFileChannel) volume.getStorage().getChannel();
+    final TrackingFileChannel tfc = new TrackingFileChannel();
+    mfc.injectChannelForTests(tfc);
     pool = volume.getStructure().getPool();
-    /*
-     * Verify that preload actually read the recorded pages back from disk.
-     * A recorded page may be served from either the volume file or the journal
-     * -- VolumeStorageV2.readPage() consults readPageFromJournal() first -- and
-     * which one is used is non-deterministic across a restart, so counting reads
-     * on an injected volume channel is racy (the original assertion
-     * intermittently saw zero reads on CI). The buffer pool's miss counter
-     * increments whenever get() loads a page from disk regardless of source, so
-     * it is the source-agnostic signal that preload did its work.
-     */
-    final long missesBefore = pool.getMissCounter();
     pool.preloadBufferInventory();
-    assertTrue("Preload should have read the recorded pages back from disk",
-        pool.getMissCounter() > missesBefore);
+    /*
+     * With the recorded pages copied back to the volume above, preload reads
+     * them through the injected volume channel rather than the journal, so the
+     * channel sees a non-empty, strictly ascending sequence of reads (warmup
+     * issues them in page order via PageNode.READ_COMPARATOR).
+     */
+    assertTrue("Preload should have read the recorded pages from the volume file",
+        tfc.getReadPositionList().size() > 0);
+    tfc.assertOrdered(true, true);
   }
 }

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -66,22 +66,6 @@ public class WarmupTest extends PersistitUnitTestCase {
 
   @Test
   public void readOrderIsSequential() throws Exception {
-    /*
-     * Stop background cleanup/pruning for this session so the buffer-pool state
-     * is deterministic. The assertion below requires that the pages recorded by
-     * the buffer inventory at shutdown are actually read back from the *volume*
-     * file (the injected TrackingFileChannel only sees volume reads). That holds
-     * only once copyBackPages() has fully drained the journal into the volume.
-     * When the background CLEANUP_MANAGER / page-writer / checkpoint activity
-     * races with copyBackPages(), the drain can be left incomplete, so on
-     * restart some recorded pages are served from the journal instead of the
-     * volume and TrackingFileChannel records zero reads -- an intermittent
-     * failure that reproduces on the CI Windows runner but not on Linux/macOS.
-     * This is the same background-eviction/cleanup interleaving that made the
-     * sibling testWarmup flaky. Disabling it makes the drain deterministic.
-     */
-    disableBackgroundCleanup();
-
     Exchange ex = _persistit.getExchange("persistit", "WarmupTest", true);
     BufferPool pool = ex.getBufferPool();
 
@@ -129,12 +113,20 @@ public class WarmupTest extends PersistitUnitTestCase {
     _persistit.initialize();
 
     final Volume volume = _persistit.getVolume("persistit");
-    final MediatedFileChannel mfc = (MediatedFileChannel) volume.getStorage().getChannel();
-    final TrackingFileChannel tfc = new TrackingFileChannel();
-    mfc.injectChannelForTests(tfc);
     pool = volume.getStructure().getPool();
+    /*
+     * Verify that preload actually read the recorded pages back from disk.
+     * A recorded page may be served from either the volume file or the journal
+     * -- VolumeStorageV2.readPage() consults readPageFromJournal() first -- and
+     * which one is used is non-deterministic across a restart, so counting reads
+     * on an injected volume channel is racy (the original assertion
+     * intermittently saw zero reads on CI). The buffer pool's miss counter
+     * increments whenever get() loads a page from disk regardless of source, so
+     * it is the source-agnostic signal that preload did its work.
+     */
+    final long missesBefore = pool.getMissCounter();
     pool.preloadBufferInventory();
-    assertTrue("Preload should have loaded pages from journal file", tfc.getReadPositionList().size() > 0);
-    tfc.assertOrdered(true, true);
+    assertTrue("Preload should have read the recorded pages back from disk",
+        pool.getMissCounter() > missesBefore);
   }
 }


### PR DESCRIPTION
Stabilizes three intermittently-failing persistit tests. (Retitled per review: the original headline change — tolerating `CorruptVolumeException` in `Bug1017957Test` — has been **reverted**; investigation confirmed the review's objection that it suppressed a real race.)

## 1. Bug 1017957 class race — real fix in `Exchange.fixIndexHole` (also standalone as #263)

The review was right: the transient `CorruptVolumeException`s ("invalid page type 30: should be 2") are a genuine race, not an observation artifact. CI traces show a descent reading a pointer under a claim on a live index page and landing on a `PAGE_TYPE_GARBAGE` page — a live index entry pointed at garbage.

Root cause: `rebalanceSplit()` links a new page only through its sibling chain and defers the parent index entry to a background `CleanupIndexHole`. Before the queue runs, a covering `removeKeyRange` can unlink that page onto a garbage chain (or it gets reused). `fixIndexHole()` validated nothing and inserted a pointer to whatever the page now holds — planting a dangling index entry (mechanism 1 of the original 2012 bug; all three original signatures fall out of this). Later covering removes delete the dangling entry, so the final `IntegrityCheck` is clean — hence the "transient" appearance. Fast JVMs iterate more and widen the race window.

Fix: under the tree reader claim (structure deletes need the writer claim, so reachability can't change), `fixIndexHole` now (a) drops the action if the page is no longer this level's type or is empty, and (b) verifies the page is still reachable in this tree — a search for its current first key at that level must land on the page itself — before inserting the pointer. See #263 for the full analysis.

The test keeps its **original strict** `assertEquals("Exception occurred", 0, totalErrors)` and is the regression detector for the fix (the race reproduces only on CI runners).

## 2. `TreeTransactionalLifetimeTest.createRemoveByStep`

Quiesce MVCC state after crash/restart (`updateActiveTransactionCache()` + `pruneTimelyResources()`), mirroring the sibling tests' idiom. (Also standalone as #260.)

## 3. `WarmupTest.readOrderIsSequential`

Deterministic setup: after the first close, reopen with inventory recording disabled and drain the journal into the volume so preload reads the recorded pages through the injected (and now actually order-checking) `TrackingFileChannel`. Fixes `TrackingFileChannel.assertOrdered`, which never advanced its cursor. (Also standalone as #259.)

## Verification

- Full `persistit/core` suite with all of the above: **565 tests, 0 failures** (5 pre-existing skips).
- `Bug1017957Test` (strict assertion) 6/6 runs green locally; `IntegrityCheckTest.testIndexFixHoles` confirms valid index holes are still repaired.
