### PR TITLE
Make WarmupTest.readOrderIsSequential deterministic

### DIFF
--- a/persistit/core/src/test/java/com/persistit/TrackingFileChannel.java
+++ b/persistit/core/src/test/java/com/persistit/TrackingFileChannel.java
@@ -163,13 +163,14 @@ class TrackingFileChannel extends FileChannel implements TestChannelInjector {
 
     public void assertOrdered(final boolean read, final boolean forward) {
         final List<Long> list = read ? _readPositions : _writePositions;
-        final long previous = forward ? -1 : Long.MAX_VALUE;
+        long previous = forward ? -1 : Long.MAX_VALUE;
         for (final Long position : list) {
             if (forward) {
                 assertTrue("Position should be larger", position > previous);
             } else {
                 assertTrue("Position should be smaller", position < previous);
             }
+            previous = position;
         }
     }
 }

--- a/persistit/core/src/test/java/com/persistit/WarmupTest.java
+++ b/persistit/core/src/test/java/com/persistit/WarmupTest.java
@@ -66,7 +66,6 @@ public class WarmupTest extends PersistitUnitTestCase {
 
   @Test
   public void readOrderIsSequential() throws Exception {
-
     Exchange ex = _persistit.getExchange("persistit", "WarmupTest", true);
     BufferPool pool = ex.getBufferPool();
 
@@ -107,11 +106,24 @@ public class WarmupTest extends PersistitUnitTestCase {
     _persistit.copyBackPages();
     _persistit.close();
 
-    _persistit = new Persistit();
+    /*
+     * recordBufferInventory() at the close above interleaves its own tree stores
+     * with the buffer scan, so some recorded pages are the inventory tree's own
+     * pages; the closing checkpoint flushes those to the journal with no
+     * copyBack(), and on restart they would be served from the journal
+     * (VolumeStorageV2.readPage consults readPageFromJournal first), bypassing
+     * the injected volume channel. Reopen with inventory recording disabled,
+     * drain the journal into the volume, and close again so every recorded page
+     * lives in the volume file; the preload below then reads them through the
+     * tracked channel deterministically instead of racing the journal.
+     */
     _config.setBufferInventoryEnabled(false);
     _config.setBufferPreloadEnabled(false);
-    _persistit.setConfiguration(_config);
-    _persistit.initialize();
+    _persistit = new Persistit(_config);
+    _persistit.copyBackPages();
+    _persistit.close();
+
+    _persistit = new Persistit(_config);
 
     final Volume volume = _persistit.getVolume("persistit");
     final MediatedFileChannel mfc = (MediatedFileChannel) volume.getStorage().getChannel();
@@ -119,7 +131,14 @@ public class WarmupTest extends PersistitUnitTestCase {
     mfc.injectChannelForTests(tfc);
     pool = volume.getStructure().getPool();
     pool.preloadBufferInventory();
-    assertTrue("Preload should have loaded pages from journal file", tfc.getReadPositionList().size() > 0);
+    /*
+     * With the recorded pages copied back to the volume above, preload reads
+     * them through the injected volume channel rather than the journal, so the
+     * channel sees a non-empty, strictly ascending sequence of reads (warmup
+     * issues them in page order via PageNode.READ_COMPARATOR).
+     */
+    assertTrue("Preload should have read the recorded pages from the volume file",
+        tfc.getReadPositionList().size() > 0);
     tfc.assertOrdered(true, true);
   }
 }


### PR DESCRIPTION
## Problem

`WarmupTest.readOrderIsSequential` is flaky: it restarts Persistit, injects a `TrackingFileChannel` into the volume channel, calls `preloadBufferInventory()`, and intermittently sees **zero** reads on that channel:

```
java.lang.AssertionError: Preload should have loaded pages from journal file
    at com.persistit.WarmupTest.readOrderIsSequential(WarmupTest.java:122)
```

## Root cause

`recordBufferInventory()` at shutdown interleaves its own `_buffer_inventory_` tree stores with its scan of the 20-buffer pool, so some recorded pages are the inventory tree's **own** pages. The closing checkpoint flushes those to the **journal** with no subsequent `copyBack()`. On restart, `VolumeStorageV2.readPage()` consults `readPageFromJournal()` first and returns without touching the volume channel, so journal-resident recorded pages bypass the injected channel entirely. When the interleaving catches enough entries, the channel records zero reads.

Two earlier attempts here were ineffective and are superseded by the head commit:
- `disableBackgroundCleanup()` bound the pre-restart instance (the test replaces it), and the background-race hypothesis was wrong;
- asserting on `pool.getMissCounter()` was vacuous — preload's walk of the shared inventory tree alone bumps the pool's single miss counter, so the test passed even if zero recorded pages loaded.

## Fix

Make the channel-based check deterministic through setup (per review):

- After the first `close()`, reopen with **buffer inventory recording disabled**, run `copyBackPages()` to drain the journal into the volume, and close again — so every recorded page (including the inventory tree's own pages) lives in the **volume file**.
- Restart, inject `TrackingFileChannel`, preload, and assert the channel saw a non-empty, strictly ascending sequence of reads.
- Fix `TrackingFileChannel.assertOrdered`: it never advanced its `previous` cursor, so it only checked `position > -1`; it now actually verifies read order (restoring the coverage the test is named for).

Note: a strict `getPageMapSize() == 0` precondition before preload turned out unachievable — the final `close()` always leaves one checkpoint page (not a data page) in the journal — so the assertions are the channel read count plus read order.

Also includes the `Bug1017957Test` stabilization commit (cherry-picked from #257) so this branch's CI is not blocked by that unrelated flake.

## Verification

- Instrumented run: preload issued **18 reads** through the injected volume channel at strictly ascending positions (`32768 … 1425408`); `assertOrdered(true, true)` verifies them with the fixed cursor.
- `readOrderIsSequential`: 10/10 consecutive green runs; full `WarmupTest`: 2/2.
- The original flake does not reproduce locally (macOS); determinism now comes from the setup sequence rather than assumptions about the read source.
