### PR TITLE
Validate the page before re-inserting an index pointer in fixIndexHole (bug 1017957 class race)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -4076,12 +4076,49 @@ public class Exchange implements ReadOnlyExchange {
       return false;
     }
     try {
+      /*
+       * This action was enqueued by rebalanceSplit() when the page was
+       * reachable only through its sibling chain, and may be arbitrarily
+       * stale by the time the background CleanupManager runs it: a covering
+       * removeKeyRange may since have unlinked the page onto a garbage chain
+       * (leaving its content and type intact, or retyping it PAGE_TYPE_GARBAGE
+       * if it became a chain root), or the page may have been reused by an
+       * unrelated allocation. Blindly inserting a key-pointer pair for such a
+       * page plants a dangling index entry to a garbage or reused page -- the
+       * bug 1017957 failure mode, observed as transient
+       * CorruptVolumeExceptions ("invalid page type 30") under concurrent
+       * structural stress. Structure deletes hold the tree writer claim, so
+       * under the reader claim held here the page's reachability cannot
+       * change; validate it before inserting the pointer.
+       */
       buffer = _pool.get(_volume, page, false, true);
+      if (buffer.getPageType() != level + PAGE_TYPE_DATA
+        || buffer.getKeyBlockEnd() <= buffer.getKeyBlockStart()) {
+        // Retyped (garbage-chain root or reused elsewhere) or empty: the
+        // index hole this action was created for no longer exists.
+        return true;
+      }
       buffer.nextKey(_spareKey2, buffer.toKeyBlock(0));
       _value.setPointerValue(page);
       _value.setPointerPageType(buffer.getPageType());
       buffer.release();
       buffer = null;
+      /*
+       * A page sitting on a garbage chain keeps its old type and content, so
+       * the type check above is not sufficient. Verify the page is still
+       * reachable in this tree: a search for its current first key at this
+       * level must land on the page itself (via the B-link right-walk, since
+       * the hole means it has no parent entry yet). If the search lands
+       * elsewhere the action is stale and inserting the pointer would corrupt
+       * the index, so drop it.
+       */
+      searchTree(_spareKey2, level, false);
+      final LevelCache lc = _levelCache[level];
+      final long landedOn = lc._page;
+      lc._buffer.releaseTouched();
+      if (landedOn != page) {
+        return true;
+      }
       storeInternal(_spareKey2, _value, level + 1, StoreOptions.NONE);
       return true;
     } finally {


### PR DESCRIPTION
## Problem

`Bug1017957Test.induceCorruptionByStress` fails intermittently on CI with transient `CorruptVolumeException`s (`invalid page type 30: should be 2`, up to 47 in one 10-second run on `macos-latest, 26`), while the final `IntegrityCheck` reports zero faults. Review of #257 argued this is a real race rather than a benign observation artifact — that turned out to be correct.

## Root cause

The CI stack traces show a descent reading a pointer **under a claim on a live index page** and landing on a page typed `PAGE_TYPE_GARBAGE` (30) — i.e. a **live index entry pointed at a garbage page**. Working back from that:

1. `rebalanceSplit()` (the `RebalanceException` path inside a spanning `removeKeyRange`) creates a page reachable **only through its sibling chain** — an index hole — and defers the parent index entry to a background `CleanupManager.CleanupIndexHole` action.
2. Before the background queue runs (poll interval up to ~1 s), a covering `removeKeyRange` joins that range: the hole page is unlinked onto a garbage chain. Its content and type survive (or it is retyped `PAGE_TYPE_GARBAGE` if it becomes a chain root), and it may be reused by an unrelated allocation.
3. `Exchange.fixIndexHole()` performed **no validation**: it read the "first key" of whatever the page now holds and inserted a key-pointer pair into the live index — planting a dangling entry to a garbage or reused page. This is exactly the bug 1017957 mechanism-1 failure mode; all three signatures from the 2012 report (`invalid page type`, `walked right more than 50 pages`, `LONG_RECORD chain is invalid`) fall out of it.
4. Subsequent covering removes delete the dangling entry, so `IntegrityCheck` at test end sees a clean volume — which is why the corruption looked "transient". Faster JVMs iterate more, producing more rebalance splits racing the background queue — hence the failures appearing on modern runners.

## Fix

Guard the insertion in `fixIndexHole()`. Structure deletes require the tree **writer** claim, so under the **reader** claim the method already holds, a page's reachability cannot change; validation is therefore race-free:

- drop the action if the page no longer has this level's page type, or is empty (retyped garbage root / reused elsewhere);
- verify the page is still reachable in this tree: a search for its current first key at that level must land on the page itself (via the B-link right-walk — that is how a hole page is reached), and drop the stale action otherwise.

No claim is held across the verification descent, preserving the parent-then-child claim order (no deadlock).

## Verification

- Full `persistit/core` suite: **565 tests, 0 failures, 0 errors** (5 pre-existing skips).
- `IntegrityCheckTest.testIndexFixHoles`: valid index holes are still repaired (the guard does not drop legitimate actions).
- `RecoveryTest.testIndexHoles`, `Bug1022567Test`, `TreeTransactionalLifetimeTest`: green.
- `Bug1017957Test.induceCorruptionByStress` with its **original strict** zero-exception assertion: 6/6 repeated runs green.
- The race itself reproduces only on CI runners (0/21 local attempts even before the fix), so CI is where this fix is ultimately validated. The strict assertion in `Bug1017957Test` — restored in #257 — is the regression detector.
