### PR TITLE
persistit: keep JournalManager consistent when rollover fails near the block end

### DIFF
--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -894,8 +894,14 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
 
     private void advance(final int recordSize) {
         Debug.$assert1.t(recordSize > 0 && recordSize + _writeBuffer.position() <= _writeBuffer.capacity());
-        _currentAddress += recordSize;
+        /*
+         * The position update validates against the buffer limit and may
+         * throw; it must happen before the _currentAddress update so that a
+         * failure cannot tear the invariant _writeBufferAddress +
+         * _writeBuffer.position() == _currentAddress.
+         */
         _writeBuffer.position(_writeBuffer.position() + recordSize);
+        _currentAddress += recordSize;
     }
 
     /**
@@ -933,8 +939,16 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
         if (_writeBufferAddress != Long.MAX_VALUE) {
             //
             // prepareWriteBuffer contract guarantees there's always room in
-            // the write buffer for this record.
+            // the write buffer for this record. However, a rollover abandoned
+            // by an exception - e.g. an interrupt during flush, truncate or
+            // force - may have consumed the reserve already, leaving
+            // _currentAddress closer than JE.OVERHEAD to the block end. Skip
+            // the JE record then, so the retried rollover can complete;
+            // recovery treats the missing JE as a dirty shutdown.
             //
+            if (_writeBuffer.remaining() < JE.OVERHEAD) {
+                return;
+            }
             JE.putType(_writeBuffer);
             JournalRecord.putTimestamp(_writeBuffer, epochalTimestamp());
             JournalRecord.putLength(_writeBuffer, JE.OVERHEAD);

--- a/persistit/core/src/main/java/com/persistit/JournalRecord.java
+++ b/persistit/core/src/main/java/com/persistit/JournalRecord.java
@@ -480,8 +480,24 @@ public class JournalRecord {
         }
     }
 
+    /**
+     * The put methods below write into the backing array directly, bypassing
+     * the ByteBuffer bounds checks. This guard makes an attempt to write
+     * beyond the buffer limit fail fast instead of silently scribbling past
+     * it (see issue #265).
+     */
+    private static int checkedPutIndex(final ByteBuffer bb, final int offset, final int size) {
+        final int index = bb.position() + offset;
+        if (index < 0 || index + size > bb.limit()) {
+            throw new IndexOutOfBoundsException(String.format(
+                    "Record write of %d bytes at position %d + offset %d exceeds buffer limit %d", size,
+                    bb.position(), offset, bb.limit()));
+        }
+        return index;
+    }
+
     private static void putByte(final ByteBuffer bb, final int offset, final int value) {
-        Util.putByte(bb.array(), bb.position() + offset, value);
+        Util.putByte(bb.array(), checkedPutIndex(bb, offset, 1), value);
     }
 
     static int getByte(final ByteBuffer bb, final int offset) {
@@ -489,7 +505,7 @@ public class JournalRecord {
     }
 
     static void putChar(final ByteBuffer bb, final int offset, final int value) {
-        Util.putChar(bb.array(), bb.position() + offset, value);
+        Util.putChar(bb.array(), checkedPutIndex(bb, offset, 2), value);
     }
 
     static int getChar(final ByteBuffer bb, final int offset) {
@@ -497,7 +513,7 @@ public class JournalRecord {
     }
 
     static void putInt(final ByteBuffer bb, final int offset, final int value) {
-        Util.putInt(bb.array(), bb.position() + offset, value);
+        Util.putInt(bb.array(), checkedPutIndex(bb, offset, 4), value);
     }
 
     static int getInt(final ByteBuffer bb, final int offset) {
@@ -505,7 +521,7 @@ public class JournalRecord {
     }
 
     static void putLong(final ByteBuffer bb, final int offset, final long value) {
-        Util.putLong(bb.array(), bb.position() + offset, value);
+        Util.putLong(bb.array(), checkedPutIndex(bb, offset, 8), value);
     }
 
     static long getLong(final ByteBuffer bb, final int offset) {
@@ -644,7 +660,8 @@ public class JournalRecord {
 
         public static void putPath(final ByteBuffer bb, final String path) {
             final byte[] stringBytes = path.getBytes(UTF8);
-            System.arraycopy(stringBytes, 0, bb.array(), bb.position() + OVERHEAD, stringBytes.length);
+            System.arraycopy(stringBytes, 0, bb.array(), checkedPutIndex(bb, OVERHEAD, stringBytes.length),
+                    stringBytes.length);
             putLength(bb, OVERHEAD + stringBytes.length);
         }
     }
@@ -778,7 +795,8 @@ public class JournalRecord {
 
         public static void putVolumeSpecification(final ByteBuffer bb, final String volumeSpec) {
             final byte[] stringBytes = volumeSpec.getBytes(UTF8);
-            System.arraycopy(stringBytes, 0, bb.array(), bb.position() + OVERHEAD, stringBytes.length);
+            System.arraycopy(stringBytes, 0, bb.array(), checkedPutIndex(bb, OVERHEAD, stringBytes.length),
+                    stringBytes.length);
             putLength(bb, OVERHEAD + stringBytes.length);
         }
     }
@@ -821,7 +839,8 @@ public class JournalRecord {
 
         public static void putTreeName(final ByteBuffer bb, final String treeName) {
             final byte[] stringBytes = treeName.getBytes(UTF8);
-            System.arraycopy(stringBytes, 0, bb.array(), bb.position() + OVERHEAD, stringBytes.length);
+            System.arraycopy(stringBytes, 0, bb.array(), checkedPutIndex(bb, OVERHEAD, stringBytes.length),
+                    stringBytes.length);
             putLength(bb, OVERHEAD + stringBytes.length);
         }
     }

--- a/persistit/core/src/test/java/com/persistit/IOFailureTest.java
+++ b/persistit/core/src/test/java/com/persistit/IOFailureTest.java
@@ -12,10 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
 
+import com.persistit.JournalRecord.JE;
+import com.persistit.JournalRecord.TX;
 import com.persistit.Transaction.CommitPolicy;
 import com.persistit.exception.CorruptJournalException;
 import com.persistit.exception.CorruptVolumeException;
@@ -26,6 +29,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Properties;
 import java.util.Timer;
@@ -412,6 +416,82 @@ public class IOFailureTest extends PersistitUnitTestCase {
     _persistit.checkAllVolumes();
     _persistit.flush();
 
+  }
+
+  /**
+   * Issue #265. An IOException thrown inside rollover() - for example an
+   * InterruptedIOException when the rolling thread is interrupted during
+   * truncate or force - after writeJournalEnd() has already advanced
+   * _currentAddress to within JE.OVERHEAD bytes of the block end used to
+   * leave the JournalManager permanently broken: the retried
+   * writeJournalEnd() wrote past the buffer limit and tore the bookkeeping
+   * invariant _writeBufferAddress + position == _currentAddress, after which
+   * every journal write failed.
+   */
+  @Test
+  public void testRolloverRecoversAfterFailureNearBlockEnd() throws Exception {
+    final JournalManager jman = _persistit.getJournalManager();
+    /*
+     * Keep the copier from moving journal addresses while the test
+     * positions _currentAddress near the block end.
+     */
+    jman.setAppendOnly(true);
+    final ErrorInjectingFileChannel eifc = errorInjectingChannel(jman.getFileChannel(jman.getCurrentAddress()));
+    final ByteBuffer payload = ByteBuffer.allocate(65536);
+    synchronized (jman) {
+      /*
+       * Write TX records sized to land _currentAddress exactly
+       * JE.OVERHEAD + 2 bytes before the end of the current block - the
+       * geometry observed in issue #265.
+       */
+      final long target = JE.OVERHEAD + 2;
+      long distance = BLOCKSIZE - jman.getCurrentJournalSize();
+      while (distance > target) {
+        long recordSize = Math.min(50000, distance - target);
+        final long rest = distance - target - recordSize;
+        if (rest > 0 && rest < TX.OVERHEAD + 8) {
+          recordSize -= TX.OVERHEAD + 8;
+        }
+        payload.clear();
+        payload.position((int) recordSize - TX.OVERHEAD);
+        jman.writeTransactionToJournal(payload, _persistit.getTimestampAllocator().updateTimestamp(),
+          TransactionStatus.ABORTED, 0);
+        distance = BLOCKSIZE - jman.getCurrentJournalSize();
+      }
+      assertEquals("Current address should sit just above the JE reserve", target, distance);
+      /*
+       * Fail the truncate() call so that rollover() aborts after
+       * writeJournalEnd() has consumed the JE reserve, as an interrupt
+       * would.
+       */
+      eifc.injectTestIOException(new IOException("injected"), "t");
+      try {
+        jman.rollover();
+        fail("rollover should have failed on the injected truncate error");
+      } catch (final PersistitIOException e) {
+        assertEquals("injected", e.getCause().getMessage());
+      }
+      assertEquals("Abandoned rollover should stop just below the block end", BLOCKSIZE - 2,
+        jman.getCurrentJournalSize());
+      /*
+       * With the failure cleared the retried rollover must complete and
+       * move to the next block.
+       */
+      eifc.injectTestIOException(null, "");
+      jman.rollover();
+      assertEquals("Retried rollover should reach the next block boundary", 0, jman.getCurrentJournalSize());
+    }
+    jman.setAppendOnly(false);
+    /*
+     * Journal writes must work again and the bookkeeping must stay
+     * consistent.
+     */
+    store1(0);
+    synchronized (jman) {
+      jman.force();
+      assertEquals("Write buffer address should agree with the current address", jman.getCurrentAddress(),
+        jman.getWriteBufferAddress());
+    }
   }
 
   private int storeUntilDiskFull() throws Exception {

--- a/persistit/core/src/test/java/com/persistit/TransactionTest2.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionTest2.java
@@ -306,8 +306,11 @@ public class TransactionTest2 extends PersistitUnitTestCase {
                 exception.printStackTrace();
                 _failedTransactionCount.incrementAndGet();
             }
-        } catch (final Exception exception) {
-            exception.printStackTrace();
+        } catch (final Throwable throwable) {
+            // Catch Throwable, not Exception: an internal Error such as an
+            // AssertionError must be reported and counted rather than
+            // silently killing the worker thread (see issue #265).
+            throwable.printStackTrace();
             _failedTransactionCount.incrementAndGet();
         }
     }


### PR DESCRIPTION
## Summary

Fixes #265.

Under sustained `Thread.interrupt()` stress the `JournalManager` write-buffer bookkeeping could be torn around a journal rollover, after which every journal writer tripped the invariant assert (`writeBufferAddress=2,999,999,998 position=0 currentAddress=3,000,000,038`). The failure is two-phase:

1. **Poisoning.** `rollover()` is not exception-safe: `writeJournalEnd()` advances `_currentAddress` by `JE.OVERHEAD` (40 bytes) to within 40 bytes of the block end, and only then does the I/O (`flush`/`truncate`/`force`). An `InterruptedIOException` there (surfaced by `MediatedFileChannel` on an interrupted thread) abandons the rollover before `_currentAddress` jumps to the next block boundary. The invariant still holds at this point, but the reserve `prepareWriteBuffer` maintains for the JE record is gone: fewer than `JE.OVERHEAD` bytes remain to the block end, and the write-buffer limit is clamped to that remainder.
2. **Tearing.** The next journal write retries the rollover. The `JE.put*` helpers write into the backing array directly, bypassing the `ByteBuffer` limit, so nothing fails until `advance(JE.OVERHEAD)` updates `_currentAddress` first and then throws from `_writeBuffer.position(...)` (`newPosition > limit`), leaving `_currentAddress` exactly 40 bytes ahead of `_writeBufferAddress + position` - the observed values. Every subsequent journal write then fails the assert (or hits the same `IllegalArgumentException` with assertions disabled).

## Changes

- `JournalManager.writeJournalEnd()`: skip the JE record when it no longer fits before the block end, so a retried rollover completes and heals the poisoned state; recovery treats the missing JE as a dirty shutdown.
- `JournalManager.advance()`: update the buffer position (which validates against the limit and may throw) before `_currentAddress`, so a failure cannot tear the invariant.
- `JournalRecord`: fail fast (`IndexOutOfBoundsException`) when a record write would exceed the buffer limit instead of silently writing past it into the backing array.
- `IOFailureTest#testRolloverRecoversAfterFailureNearBlockEnd`: deterministic reproduction - positions `_currentAddress` exactly `JE.OVERHEAD + 2` bytes before the block end, aborts the rollover with an injected `truncate()` failure, verifies the poisoned geometry, then verifies the retried rollover heals and journal writes keep working.
- `TransactionTest2`: workers catch `Throwable` so an internal `Error` is reported and counted instead of silently killing the thread (the cascade that polluted `transactionsConcurrentWithPersistitClose` in the same CI run).

## Testing

- The new test fails on the unfixed code with `IllegalArgumentException: newPosition > limit: (40 > 2)` (and the same error from `tearDown`, showing the state never heals) and passes with the fix.
- Full `persistit/core` suite: 566 tests, 0 failures, 0 errors, 5 pre-existing skips.
