### PR TITLE
persistit: do not accept short writes when copying pages to the volume

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Buffer.java
+++ b/persistit/core/src/main/java/com/persistit/Buffer.java
@@ -486,8 +486,22 @@ public class Buffer extends SharedResource {
                 _slack = 0;
                 _rightSibling = 0;
             } else {
-                Debug.$assert0.t(getByte(BUFFER_LENGTH_OFFSET) * 256 == _bufferSize);
-                Debug.$assert0.t(getLong(PAGE_ADDRESS_OFFSET) == _page);
+                /*
+                 * Hard checks, not Debug asserts: a page whose stored length
+                 * or address does not match holds stale or torn content
+                 * (e.g. from a partially transferred write) and must fail
+                 * loudly here rather than surface later as silently wrong
+                 * data.
+                 */
+                if (getByte(BUFFER_LENGTH_OFFSET) * 256 != _bufferSize) {
+                    throw new InvalidPageStructureException("Invalid buffer length "
+                            + (getByte(BUFFER_LENGTH_OFFSET) * 256) + " in content of page " + _page + ": expected "
+                            + _bufferSize);
+                }
+                if (getLong(PAGE_ADDRESS_OFFSET) != _page) {
+                    throw new InvalidPageStructureException("Invalid page address " + getLong(PAGE_ADDRESS_OFFSET)
+                            + " in content of page " + _page);
+                }
                 _alloc = getChar(FREE_OFFSET);
                 _slack = getChar(SLACK_OFFSET);
                 _rightSibling = getLong(RIGHT_SIBLING_OFFSET);

--- a/persistit/core/src/main/java/com/persistit/VolumeStorageV2.java
+++ b/persistit/core/src/main/java/com/persistit/VolumeStorageV2.java
@@ -507,7 +507,24 @@ class VolumeStorageV2 extends VolumeStorage {
         }
 
         try {
-            _channel.write(bb, page * _volume.getStructure().getPageSize());
+            /*
+             * FileChannel#write may report partial progress instead of
+             * throwing - observed empirically on disk-full, and possible for
+             * transfers aborted by a concurrent interrupt-driven channel
+             * close. Accepting a short count here would silently tear the
+             * page in the volume file, so write until every byte has been
+             * transferred, mirroring the read loop in readPage.
+             */
+            final int size = bb.remaining();
+            final long position = page * _volume.getStructure().getPageSize();
+            int written = 0;
+            while (written < size) {
+                final int bytesWritten = _channel.write(bb, position + written);
+                if (bytesWritten <= 0) {
+                    throw new IOException("Unable to write bytes at position " + (position + written) + " in " + this);
+                }
+                written += bytesWritten;
+            }
         } catch (final IOException ioe) {
             _persistit.getAlertMonitor().post(
                     new Event(AlertLevel.ERROR, _persistit.getLogBase().writeException, ioe, _volume, page),

--- a/persistit/core/src/test/java/com/persistit/ErrorInjectingFileChannel.java
+++ b/persistit/core/src/test/java/com/persistit/ErrorInjectingFileChannel.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -44,6 +45,7 @@ class ErrorInjectingFileChannel extends FileChannel implements TestChannelInject
     volatile IOException _injectedIOException;
     volatile String _injectedIOExceptionFlags;
     volatile long _injectedDiskFullLimit = Long.MAX_VALUE;
+    volatile long _injectedShortWritePosition = -1;
 
     @Override
     public void setChannel(final FileChannel channel) {
@@ -87,11 +89,25 @@ class ErrorInjectingFileChannel extends FileChannel implements TestChannelInject
     /**
      * Sets a file position at which writes will simulate a disk-full condition
      * by throwing an IOException.
-     * 
+     *
      * @param limit
      */
     void injectDiskFullLimit(final long limit) {
         _injectedDiskFullLimit = limit;
+    }
+
+    /**
+     * Arms a one-shot short write: the next write that spans the supplied
+     * position transfers only the bytes below it and returns the partial
+     * count without throwing. This mimics a transfer aborted mid-flight
+     * (e.g. by a concurrent close of the channel on Windows) and the
+     * empirically observed disk-full behavior of FileChannel#write, both of
+     * which report partial progress instead of failing.
+     *
+     * @param position
+     */
+    void injectShortWriteOnce(final long position) {
+        _injectedShortWritePosition = position;
     }
 
     @Override
@@ -144,6 +160,15 @@ class ErrorInjectingFileChannel extends FileChannel implements TestChannelInject
         injectFailure('w');
         if (byteBuffer.remaining() == 1) {
             injectFailure('e');
+        }
+        final long shortWriteAt = _injectedShortWritePosition;
+        if (shortWriteAt >= 0 && position <= shortWriteAt && position + byteBuffer.remaining() > shortWriteAt) {
+            _injectedShortWritePosition = -1;
+            final int delta = (int) (position + byteBuffer.remaining() - shortWriteAt);
+            byteBuffer.limit(byteBuffer.limit() - delta);
+            final int written = byteBuffer.hasRemaining() ? _channel.write(byteBuffer, position) : 0;
+            byteBuffer.limit(byteBuffer.limit() + delta);
+            return written;
         }
         final long capacity = Math.max(0L, _injectedDiskFullLimit - position);
         final int delta = (int) Math.max(0L, byteBuffer.remaining() - capacity);

--- a/persistit/core/src/test/java/com/persistit/IOFailureTest.java
+++ b/persistit/core/src/test/java/com/persistit/IOFailureTest.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -280,6 +281,43 @@ public class IOFailureTest extends PersistitUnitTestCase {
     volume.getPool().invalidate(volume);
   }
 
+  /**
+   * Issue #268. FileChannel#write may report partial progress instead of
+   * throwing - observed empirically on disk-full, and suspected for
+   * transfers aborted by a concurrent interrupt-driven channel close on
+   * Windows. VolumeStorageV2.writePage used to ignore the returned count,
+   * so a short write during copyback silently tore the page in the volume
+   * file: intact header, stale tail. The journal copy was then dropped by
+   * cleanupForCopy, the pool evicted the page, and a later read served the
+   * torn page with no error - resurrecting stale record versions.
+   */
+  @Test
+  public void testVolumeShortWriteMustNotTearPage() throws Exception {
+    store1(0);
+    final Volume volume = _persistit.getVolume(_volumeName);
+    final ErrorInjectingFileChannel eifc = errorInjectingChannel(volume.getStorage().getChannel());
+    /*
+     * The next volume write that spans the middle of page 6 - a tree page
+     * after store1 - transfers only half the page and returns the short
+     * count without an exception, exactly once. Subsequent writes are
+     * normal, so the copyback cycle completes and cleanupForCopy drops the
+     * journal copies, making the volume file authoritative.
+     */
+    final int pageSize = volume.getPageSize();
+    eifc.injectShortWriteOnce(6L * pageSize + pageSize / 2);
+    _persistit.copyBackPages();
+    /*
+     * Force every subsequent read to come from the volume file.
+     */
+    volume.getPool().flush(Long.MAX_VALUE);
+    _persistit.getJournalManager().force();
+    volume.getPool().invalidate(volume);
+    /*
+     * All records must read back intact through the volume channel.
+     */
+    checkStore1(0);
+  }
+
   @Test
   public void testJournalEOFonRecovery() throws Exception {
     final JournalManager jman = _persistit.getJournalManager();
@@ -461,6 +499,21 @@ public class IOFailureTest extends PersistitUnitTestCase {
       exchange.clear().append(at).append(sb);
       exchange.getValue().put("Record #" + at + "_" + i);
       exchange.store();
+    }
+    _persistit.releaseExchange(exchange);
+  }
+
+  private void checkStore1(final int at) throws PersistitException {
+    final Exchange exchange = _persistit.getExchange(_volumeName, "IOFailureTest", false);
+    final StringBuilder sb = new StringBuilder();
+
+    for (int i = 1; i <= 5000; i++) {
+      sb.setLength(0);
+      sb.append((char) (i / 20 + 64));
+      sb.append((char) (i % 20 + 64));
+      exchange.clear().append(at).append(sb).fetch();
+      assertEquals("Record " + at + "_" + i + " should read back intact", "Record #" + at + "_" + i, exchange
+        .getValue().isDefined() ? exchange.getValue().getString() : null);
     }
     _persistit.releaseExchange(exchange);
   }


### PR DESCRIPTION
## Summary

Fixes #268.

`FileChannel#write` may report partial progress instead of throwing — the original persistit authors observed this empirically on disk-full (see the comment in `JournalManager#flush`), and the same reporting is possible for transfers aborted by a concurrent interrupt-driven channel close (`CancelIoEx` on Windows), the suspected mechanism behind the Windows-only integrity violations in `TransactionTest2.transactionsWithInterrupts`.

`VolumeStorageV2.writePage(ByteBuffer, long)` ignored the returned count — a single unchecked `_channel.write()` call, in contrast to `readPage` directly above it, which loops until the page is fully read. A short write during copyback therefore silently tore the page in the volume file: intact header, stale tail. The failure chain to the observed silent corruption:

1. The copier writes the page to the volume on the channel it shares with worker threads; a worker interrupted mid-I/O closes that channel under the copier.
2. The short count is accepted; `cleanupForCopy` drops the journal copy, making the torn volume page authoritative.
3. The pool evicts the page; a later read serves the torn page — `Buffer.load()` validated nothing beyond a type-byte range check (the page-address and buffer-length checks were disabled `Debug` asserts, and all checked fields live in the intact header).
4. Stale record versions in the tail resurrect old values — a silent integrity violation with no exception anywhere, matching the balance mismatches on Windows CI.

Commit/rollback bookkeeping was audited and is exception-safe (abort is marked before any I/O; commit's `finally` aborts on flush failure), which rules out the transaction paths and leaves torn page I/O as the identified silent-corruption vector.

## Changes

- `VolumeStorageV2.writePage(ByteBuffer, long)`: write until every byte is transferred, mirroring the `readPage` loop; throw `PersistitIOException` when no progress is made — safe, because the copier retains the page in the page map and retries the copy on the next cycle.
- `Buffer.load()`: turn the buffer-length and page-address `Debug` asserts into hard `InvalidPageStructureException` checks, so stale or torn page content fails loudly instead of surfacing later as silently wrong data.
- `ErrorInjectingFileChannel`: add a one-shot short-write injection (`injectShortWriteOnce`) that transfers only the bytes below a given position and returns the partial count without throwing, mimicking an aborted transfer.
- `IOFailureTest#testVolumeShortWriteMustNotTearPage`: deterministic end-to-end reproduction — a one-shot short write mid-page during `copyBackPages()`, then pool invalidation and full read-back verification. Without the fix it fails with `CorruptVolumeException: ... page=6 ... is before left edge`; with the fix the write loop transparently completes the transfer and all records read back intact.

## Testing

- New test red on the unfixed code, green with the fix.
- `Buffer.load()`-sensitive classes (`BufferTest`, `MVCCPruneBufferTest`, `RecoveryTest`, `CorruptVolumeTest`, `WarmupTest`, `BufferPoolTest`, `IntegrityCheckTest`): all green.
- Full `persistit/core` suite: 566 tests, 0 failures, 0 errors, 5 pre-existing skips.

#258 (a Windows skip for `transactionsWithInterrupts`) was closed in favor of this fix: the test keeps running on Windows, so CI there validates the fix on the affected platform; a residual failure would now surface as a loud `InvalidPageStructureException` rather than a silent balance mismatch (tracked in #268).

