### PR TITLE
Run integration tests in the default CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Build with Maven
       env:
         MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
-      run: mvn --batch-mode --errors --update-snapshots package --file pom.xml
+      run: mvn --batch-mode --errors --update-snapshots verify --file pom.xml


### PR DESCRIPTION
## Problem

The Build Maven workflow runs `mvn package`, which stops before the `integration-test` and `verify` phases. As a result, the failsafe integration tests (`*IT.java`) never run on pull requests:

- `commons/auth-filters/authn-filter/jaspi-functional-tests` — 7 TestNG IT classes (run in-process, no container)
- `commons/auth-filters/authz-filter/framework-functional-tests` — TestNG ITs deployed to Tomcat 10/11 via Cargo (surefire is explicitly excluded there, so nothing runs at all)

They were only exercised indirectly by the deploy workflow on `master` (`mvn deploy` goes through the full lifecycle).

## Change

Switch the build command from `mvn package` to `mvn verify`, so every CI build runs the integration tests. This also activates the `verify`-phase checks that were previously skipped: the persistit animal-sniffer Java API compatibility check and source jar attachment.

## Validation

- Local `mvn verify` on both functional-test modules (JDK 26): 48 + 72 tests pass, including Tomcat 11 startup via Cargo.
- Local `mvn verify` on persistit modules: animal-sniffer check passes.
- The deploy workflow on `master` already runs these phases via `mvn deploy` (JDK 11, ubuntu) and is consistently green.