### PR TITLE
persistit: stabilize flaky MVCCPruneTest.testPruneAlternatingAbortedAndCommittedVersions

### DIFF
--- a/persistit/core/src/test/java/com/persistit/MVCCPruneTest.java
+++ b/persistit/core/src/test/java/com/persistit/MVCCPruneTest.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
@@ -253,6 +254,15 @@ public class MVCCPruneTest extends MVCCTestBase {
         storePrimordial(ex1, KEY, VALUE);
 
         for (int i = 0; i < VERSIONS.length; ++i) {
+            /*
+             * The prune that runs inside each store consults the active
+             * transaction cache: a stale cache conservatively keeps the
+             * previous committed version, a fresh one removes it. Settle the
+             * cache before every store so the surviving version count does
+             * not depend on whether the background TXN_UPDATE timer fired
+             * mid-loop (issue #272).
+             */
+            _persistit.getTransactionIndex().updateActiveTransactionCache();
             trx1.begin();
             try {
                 store(ex1, KEY, VALUE + VERSIONS[i] + i);
@@ -265,7 +275,7 @@ public class MVCCPruneTest extends MVCCTestBase {
                 trx1.end();
             }
         }
-        final int VERSIONS_NOW_REMOVED_BY_PRUNING_BEFORE_STORE = 2;
+        final int VERSIONS_NOW_REMOVED_BY_PRUNING_BEFORE_STORE = 4;
         assertEquals("stored versions", VERSIONS.length + 1 - VERSIONS_NOW_REMOVED_BY_PRUNING_BEFORE_STORE,
                 storedVersionCount(ex2, KEY));
 


### PR DESCRIPTION
## Summary

Fixes the flaky `MVCCPruneTest.testPruneAlternatingAbortedAndCommittedVersions`, which intermittently failed on CI with:

```
com.persistit.MVCCPruneTest.testPruneAlternatingAbortedAndCommittedVersions:269
  stored versions expected:<4> but was:<3>
```

## Root cause

The prune that runs inside every MVCC store (`Exchange.storeInternal` -> `MVV.prune`) decides whether to drop the previous committed version by calling `TransactionIndex.hasConcurrentTransaction`, which consults the ActiveTransactionCache:

- **stale cache** (ceiling below the version's commit timestamp) — conservatively keeps the older committed/primordial version;
- **fresh cache** — removes it.

The test hardcoded the stale-cache outcome (`VERSIONS_NOW_REMOVED_BY_PRUNING_BEFORE_STORE = 2`: only the two aborted versions pruned). That assumption holds only while the whole 5-transaction loop fits between two ticks of the background `TXN_UPDATE` poll task, which recomputes the cache every 10 ms (`TransactionIndex.POLLING_TASK_INTERVAL`). On a loaded CI runner a recompute lands mid-loop, the store-time prune drops an extra version (the primordial one or the older committed one), and the count assertion fails with 3 (or theoretically 2) instead of 4.

The race is unrelated to recent changes (the init-time settling added for #264 runs before any test data exists) — it dates back to the introduction of prune-before-store; slow runners just made it visible.

## Fix

Drive pruning deterministically instead of relying on timer phase: settle the active transaction cache explicitly before every store in the loop, so the prune always sees fresh commit status. The surviving-version count then has a single deterministic value — 4 versions removed (two aborted + primordial + the older committed one), 2 surviving — regardless of any additional background recomputes, which are idempotent at that point. The final assertion of the test (2 stored versions after the explicit prune) is unaffected.

This mirrors the deterministic-settling approach used for the other persistit/core flakes (#254, #255, #256, #259, #261, #262, #266).

## Testing

- `MVCCPruneTest` full class under JDK 11: 14/14 green.
- Target method run 5 additional times in isolation: green.

Fixes #272.
