### PR TITLE
persistit: revalidate pending index insertions after the tree claim is dropped mid-store (bug 1017957 residual)

### DIFF
--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -63,6 +63,7 @@ import static com.persistit.Key.LTEQ;
 import static com.persistit.Key.RIGHT_GUARD_KEY;
 import static com.persistit.Key.maxStorableKeySize;
 import static com.persistit.util.SequencerConstants.DEALLOCATE_CHAIN_A;
+import static com.persistit.util.SequencerConstants.STORE_PENDING_SPLIT_A;
 import static com.persistit.util.SequencerConstants.WRITE_WRITE_STORE_A;
 import static com.persistit.util.ThreadSequencer.sequence;
 
@@ -1399,6 +1400,8 @@ public class Exchange implements ReadOnlyExchange {
     boolean treeWriterClaimRequired = false;
     boolean committed = false;
     boolean incrementMVVCount = false;
+    final int startLevel = level;
+    boolean revalidateSplitPointer = false;
 
     final int maxSimpleValueSize = maxValueSize(key.getEncodedSize());
     final Value spareValue = _persistit.getThreadLocalValue();
@@ -1470,6 +1473,32 @@ public class Exchange implements ReadOnlyExchange {
         }
 
         checkLevelCache();
+
+        /*
+         * A prior iteration committed a split at level - 1 and the
+         * RetryException handler below then released the tree claim before
+         * re-acquiring it. While no claim was held a concurrent structure
+         * delete may have unlinked the page the pending key-pointer pair
+         * refers to and put it on a garbage chain; blindly inserting the
+         * pointer would plant a dangling index entry to a garbage page --
+         * the bug 1017957 failure mode. Re-validate under the re-acquired
+         * claim: a search for the pending key at the child level must land
+         * on the pending page itself (through the B-link right-walk, since
+         * the page has no parent entry yet). If it lands elsewhere the page
+         * is gone, along with its keys, and the deferred insertion must be
+         * abandoned.
+         */
+        if (revalidateSplitPointer) {
+          revalidateSplitPointer = false;
+          searchTree(key, level - 1, false);
+          final Buffer childBuffer = _levelCache[level - 1]._buffer;
+          final long landedOn = childBuffer.getPageAddress();
+          childBuffer.releaseTouched();
+          if (landedOn != valueToStore.getPointerValue()) {
+            break mainRetryLoop;
+          }
+        }
+
         final List<PrunedVersion> prunedVersions = new ArrayList<PrunedVersion>();
 
         try {
@@ -1716,6 +1745,9 @@ public class Exchange implements ReadOnlyExchange {
             _treeHolder.release();
             treeClaimAcquired = false;
           }
+          if (level > startLevel) {
+            revalidateSplitPointer = true;
+          }
           try {
             sequence(WRITE_WRITE_STORE_A);
             final long depends = _persistit.getTransactionIndex().wwDependency(re.getVersionHandle(),
@@ -1740,6 +1772,16 @@ public class Exchange implements ReadOnlyExchange {
           if (treeClaimAcquired) {
             _treeHolder.release();
             treeClaimAcquired = false;
+          }
+          if (level > startLevel) {
+            /*
+             * A split committed at a lower level and its key-pointer pair
+             * has not been inserted yet. The claim release above opens a
+             * window for a concurrent structure delete, so the pending
+             * insertion must be re-validated at the top of the loop.
+             */
+            revalidateSplitPointer = true;
+            sequence(STORE_PENDING_SPLIT_A);
           }
           final boolean doWait = (options & StoreOptions.WAIT) != 0;
           treeClaimAcquired = _treeHolder.claim(true, doWait ? _timeoutMillis : 0);
@@ -4114,6 +4156,37 @@ public class Exchange implements ReadOnlyExchange {
       lc._buffer.releaseTouched();
       if (landedOn != page) {
         return true;
+      }
+      /*
+       * Both checks above can pass legitimately for the wrong incarnation of
+       * the page: since this action was enqueued, the page may have been
+       * unlinked, garbage-collected and reused as a live page of this tree at
+       * the same level (ABA). A reused page is already indexed, so the search
+       * lands on it through its own parent entry rather than through the
+       * B-link right-walk from its left sibling, and the insert below would
+       * target a page that has no index hole. That insert is a harmless
+       * same-key replace only while every parent entry key equals its page's
+       * first key -- a global invariant this repair action has no business
+       * depending on; were the keys ever to diverge it would plant a second
+       * parent entry for the page, and a later covering removeKeyRange could
+       * unlink the page while deleting only one of the two entries, leaving
+       * a dangling pointer. Repair the hole only if the parent level really
+       * has no entry for this page: the entry covering the page's first key
+       * must be non-exact and point elsewhere (to the left sibling the
+       * right-walk came through).
+       */
+      if (level + 1 < _cacheDepth) {
+        final int foundAtParent = searchTree(_spareKey2, level + 1, false);
+        final Buffer parentBuffer = _levelCache[level + 1]._buffer;
+        boolean indexed = (foundAtParent & EXACT_MASK) != 0;
+        if (!indexed) {
+          final int p = parentBuffer.previousKeyBlock(foundAtParent & P_MASK);
+          indexed = p == -1 || parentBuffer.getPointer(p) == page;
+        }
+        parentBuffer.releaseTouched();
+        if (indexed) {
+          return true;
+        }
       }
       storeInternal(_spareKey2, _value, level + 1, StoreOptions.NONE);
       return true;

--- a/persistit/core/src/main/java/com/persistit/util/SequencerConstants.java
+++ b/persistit/core/src/main/java/com/persistit/util/SequencerConstants.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit.util;
@@ -92,6 +93,18 @@ public interface SequencerConstants {
     int[][] DEALLOCATE_CHAIN_SCHEDULED = new int[][] { array(DEALLOCATE_CHAIN_A, DEALLOCATE_CHAIN_B),
             array(DEALLOCATE_CHAIN_B), array(DEALLOCATE_CHAIN_A, DEALLOCATE_CHAIN_C),
             array(DEALLOCATE_CHAIN_A, DEALLOCATE_CHAIN_C) };
+
+    /*
+     * Used in testing the deferred key-pointer insertion that is left pending
+     * when Exchange#storeInternal releases the tree claim on a RetryException
+     * after a split has already committed, bug 1017957 residual
+     */
+    int STORE_PENDING_SPLIT_A = allocate("STORE_PENDING_SPLIT_A");
+    int STORE_PENDING_SPLIT_B = allocate("STORE_PENDING_SPLIT_B");
+    int STORE_PENDING_SPLIT_C = allocate("STORE_PENDING_SPLIT_C");
+    int[][] STORE_PENDING_SPLIT_SCHEDULE = new int[][] { array(STORE_PENDING_SPLIT_A, STORE_PENDING_SPLIT_B),
+            array(STORE_PENDING_SPLIT_B), array(STORE_PENDING_SPLIT_A, STORE_PENDING_SPLIT_C),
+            array(STORE_PENDING_SPLIT_A, STORE_PENDING_SPLIT_C) };
 
     /*
      * Used in testing delete/deallocate sequence in Bug1064565Test

--- a/persistit/core/src/test/java/com/persistit/Bug1017957ResidualTest.java
+++ b/persistit/core/src/test/java/com/persistit/Bug1017957ResidualTest.java
@@ -1,0 +1,395 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+
+package com.persistit;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.persistit.exception.PersistitException;
+import com.persistit.util.ThreadSequencer;
+import com.persistit.util.ThreadSequencer.Condition;
+
+import static com.persistit.util.SequencerConstants.STORE_PENDING_SPLIT_A;
+import static com.persistit.util.SequencerConstants.STORE_PENDING_SPLIT_B;
+import static com.persistit.util.SequencerConstants.STORE_PENDING_SPLIT_C;
+import static com.persistit.util.SequencerConstants.STORE_PENDING_SPLIT_SCHEDULE;
+import static com.persistit.util.ThreadSequencer.addSchedules;
+import static com.persistit.util.ThreadSequencer.enableSequencer;
+import static com.persistit.util.ThreadSequencer.sequence;
+import static com.persistit.util.ThreadSequencer.setCondition;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic reproductions of the residual bug-1017957 class races reported
+ * in https://github.com/OpenIdentityPlatform/commons/issues/274. The original
+ * {@link Bug1017957Test#induceCorruptionByStress()} reproduces them only
+ * probabilistically under a 10-second two-thread stress.
+ *
+ * <p>
+ * Mechanism reproduced by
+ * {@link #pendingSplitPointerRevalidatedAfterTreeClaimDrop()}: when
+ * {@code Exchange#storeInternal} has committed a split at some level, the
+ * key-pointer pair for the new right sibling is inserted at the next level by
+ * a later iteration of the store loop. If that iteration throws a
+ * RetryException (tree height growth with a contended claim upgrade), the
+ * handler releases the tree claim entirely before re-acquiring it. In that
+ * window a concurrent structure delete can unlink the new page and put it on
+ * a garbage chain; the resumed iteration used to insert the now-stale pointer
+ * blindly, planting a dangling index entry to a garbage page. Searches then
+ * fail transiently with {@code CorruptVolumeException "invalid page type 30"}
+ * while the volume is consistent at rest -- exactly the CI signature of issue
+ * #274.
+ *
+ * <p>
+ * Hardening covered by {@link #staleIndexHoleActionOnReusedPageIsDropped()}:
+ * a {@code CleanupIndexHole} action enqueued by {@code rebalanceSplit} may
+ * run arbitrarily late. By then the page may have been unlinked, garbage
+ * collected and reused as a live, indexed page of the same tree at the same
+ * level (ABA). The type and reachability checks of {@code fixIndexHole} both
+ * pass legitimately against the new incarnation, so the action used to
+ * perform a parent-level store against a page that has no index hole. That
+ * store happens to be a same-key replace only while every parent entry key
+ * equals its page's first key; the parent-entry check makes the guard
+ * independent of that invariant and drops the stale action outright.
+ */
+public class Bug1017957ResidualTest extends PersistitUnitTestCase {
+
+  private final static String TREE_NAME = "Bug1017957Residual";
+
+  @Override
+  protected Properties doGetProperties(final boolean cleanup) {
+    return getBiggerProperties(cleanup);
+  }
+
+  private Exchange getExchange() throws PersistitException {
+    return _persistit.getExchange(VOLUME_NAME, TREE_NAME, true);
+  }
+
+  /**
+   * A stale CleanupIndexHole action whose page has been garbage collected and
+   * reused as a live indexed page of the same tree must be dropped without
+   * storing anything. Before the parent-entry check the action passed both
+   * guards of fixIndexHole against the reused incarnation and performed a
+   * parent-level store; that store is harmless only while every parent entry
+   * key equals its page's first key, a global invariant the repair action has
+   * no business depending on.
+   */
+  @Test
+  public void staleIndexHoleActionOnReusedPageIsDropped() throws Exception {
+    /*
+     * Keep the background CleanupManager from running anything while the
+     * scenario is constructed; the stale action is performed synchronously.
+     */
+    _persistit.getCleanupManager().setPollInterval(3600 * 1000L);
+
+    final Exchange ex = getExchange();
+    final int treeHandle = _persistit.getJournalManager().handleForTree(ex.getTree());
+
+    /*
+     * Lay down several data pages with large keys and values, then map each
+     * key to its data page so that three adjacent pages L, P, R and their
+     * lowest keys are known.
+     */
+    final String v = createString(5500);
+    final String k = createString(1040);
+    for (int i = 1000; i < 1019; i++) {
+      ex.clear().append(i).append(k);
+      ex.getValue().put(v);
+      ex.store();
+    }
+    final List<Long> pages = new ArrayList<Long>();
+    final List<Integer> lowestKeys = new ArrayList<Integer>();
+    for (int i = 1000; i < 1019; i++) {
+      ex.clear().append(i).append(k);
+      final long page = ex.fetchBufferCopy(0).getPageAddress();
+      if (pages.isEmpty() || pages.get(pages.size() - 1) != page) {
+        pages.add(page);
+        lowestKeys.add(i);
+      }
+    }
+    assertTrue("Need at least 4 data pages, got " + pages.size(), pages.size() >= 4);
+    final int middle = pages.size() / 2;
+    final long targetPage = pages.get(middle);
+
+    /*
+     * The stale action: enqueued for the current incarnation of targetPage,
+     * performed only after the page has been unlinked and reused.
+     */
+    final CleanupManager.CleanupIndexHole action = new CleanupManager.CleanupIndexHole(treeHandle, targetPage, 0);
+
+    /*
+     * Unlink targetPage: remove everything from the lowest key of its left
+     * neighbor up to (exclusive) the lowest key of its right neighbor, so
+     * that targetPage is interior to the removed range and gets unlinked
+     * onto a garbage chain. The bounds are partial keys (first segment
+     * only), as in Bug1017957Test, so they never match a stored key or an
+     * index separator exactly.
+     */
+    final Key key1 = new Key(_persistit);
+    key1.append(lowestKeys.get(middle - 1));
+    final Key key2 = new Key(_persistit);
+    key2.append(lowestKeys.get(middle + 1));
+    ex.removeKeyRange(key1, key2);
+
+    /*
+     * Reuse targetPage: append small records until the page comes back from
+     * the garbage chain as a live, indexed data page of this tree. With a
+     * sequential append workload the reused page starts out as the
+     * rightmost data page.
+     */
+    int appended = -1;
+    for (int i = 0; i < 4000 && appended < 0; i++) {
+      ex.clear().append(5000 + i);
+      ex.getValue().put(RED_FOX);
+      ex.store();
+      if (isLiveDataPageOfTree(ex, targetPage)) {
+        appended = i;
+      }
+    }
+    assertTrue("Page " + targetPage + " was not reused as a live data page", appended >= 0);
+
+    assertEquals("Reused page must have exactly one parent entry before the stale action", 1,
+      countIndexPointersTo(targetPage));
+
+    final long storesBefore = ex.getTree().getStatistics().getStoreCounter();
+    action.performAction(_persistit, null);
+
+    assertEquals("Stale CleanupIndexHole on a reused page must be dropped, not stored", storesBefore,
+      ex.getTree().getStatistics().getStoreCounter());
+    assertEquals("Reused page must still have exactly one parent entry", 1, countIndexPointersTo(targetPage));
+
+    final IntegrityCheck icheck = new IntegrityCheck(_persistit);
+    icheck.checkVolume(_persistit.getVolume(VOLUME_NAME));
+    assertEquals("Volume must be consistent", 0, icheck.getFaults().length);
+  }
+
+  /**
+   * A key-pointer pair left pending by a committed split must be re-validated
+   * when the tree claim was released on a RetryException: a concurrent
+   * covering remove may have unlinked the page the pointer refers to.
+   */
+  @Test
+  public void pendingSplitPointerRevalidatedAfterTreeClaimDrop() throws Exception {
+    _persistit.getCleanupManager().setPollInterval(3600 * 1000L);
+    try {
+      enableSequencer(true);
+      addSchedules(STORE_PENDING_SPLIT_SCHEDULE);
+
+      final Exchange ex = getExchange();
+      final Tree tree = ex.getTree();
+      final String v = createString(5500);
+      final String k = createString(1040);
+      /*
+       * Build a depth-2 tree: one index level (the root) over data pages.
+       */
+      int prefill = 1000;
+      while (tree.getDepth() < 2 || prefill < 1010) {
+        ex.clear().append(prefill).append(k);
+        ex.getValue().put(v);
+        ex.store();
+        prefill++;
+      }
+      assertEquals(2, tree.getDepth());
+
+      /*
+       * Hold a reader claim on the tree so that the writer thread's attempt
+       * to grow the tree height fails its claim upgrade and takes the
+       * RetryException path, parking at STORE_PENDING_SPLIT_A after having
+       * released all claims with the root split already committed.
+       */
+      assertTrue(tree.claim(false));
+      boolean treeClaimHeld = true;
+
+      final AtomicBoolean done = new AtomicBoolean();
+      final AtomicInteger lastStored = new AtomicInteger();
+      final AtomicReference<Exception> writerError = new AtomicReference<Exception>();
+      final Thread writer = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            final Exchange ex1 = getExchange();
+            int i = 2000;
+            while (!done.get()) {
+              ex1.clear().append(i).append(k);
+              ex1.getValue().put(v);
+              ex1.store();
+              lastStored.set(i);
+              i++;
+            }
+          } catch (final Exception e) {
+            writerError.set(e);
+          }
+        }
+      });
+      setCondition(STORE_PENDING_SPLIT_A, new Condition() {
+        @Override
+        public boolean enabled() {
+          return Thread.currentThread() == writer;
+        }
+      });
+      writer.start();
+
+      try {
+        /*
+         * Wait until the writer is parked inside the RetryException window.
+         * The root split has committed: the old root has a new right
+         * sibling that is not yet indexed, and the writer holds no claims.
+         */
+        sequence(STORE_PENDING_SPLIT_B);
+
+        final long rootPage = tree.getRootPageAddr();
+        final long pendingPage = rightSiblingOf(rootPage);
+        assertTrue("Root split must have linked a right sibling", pendingPage != 0);
+
+        tree.release();
+        treeClaimHeld = false;
+
+        /*
+         * Covering remove: delete a range that spans from the old root's
+         * coverage into the pending page's coverage. The index-level join
+         * coalesces the pending page back into the root and unlinks it onto
+         * a garbage chain, where it is retyped to PAGE_TYPE_GARBAGE.
+         */
+        final Key key1 = new Key(_persistit);
+        key1.append(1002);
+        final Key key2 = new Key(_persistit);
+        key2.append(lastStored.get());
+        ex.removeKeyRange(key1, key2);
+
+        assertEquals("The pending page must have been unlinked and garbage collected",
+          Buffer.PAGE_TYPE_GARBAGE, pageTypeOf(pendingPage));
+
+        done.set(true);
+        sequence(STORE_PENDING_SPLIT_C);
+        writer.join(60 * 1000L);
+        assertTrue("Writer thread must terminate", !writer.isAlive());
+        assertNull("Writer thread must not fail: " + writerError.get(), writerError.get());
+
+        assertEquals("No index entry may point to the garbage page", 0, countIndexPointersTo(pendingPage));
+
+        final IntegrityCheck icheck = new IntegrityCheck(_persistit);
+        icheck.checkVolume(_persistit.getVolume(VOLUME_NAME));
+        assertEquals("Volume must be consistent", 0, icheck.getFaults().length);
+
+        /*
+         * The CI signature of issue #274: a traversal used to throw a
+         * transient CorruptVolumeException "invalid page type 30" while
+         * descending through the dangling entry.
+         */
+        ex.clear().to(Key.AFTER);
+        int remaining = 0;
+        while (ex.previous()) {
+          remaining++;
+        }
+        assertTrue("Some keys must remain", remaining > 0);
+      } finally {
+        done.set(true);
+        if (treeClaimHeld) {
+          tree.release();
+        }
+        /*
+         * Disabling the sequencer releases the writer if an assertion fired
+         * before STORE_PENDING_SPLIT_C was reached.
+         */
+        ThreadSequencer.disableSequencer();
+        writer.join(60 * 1000L);
+      }
+    } finally {
+      ThreadSequencer.disableSequencer();
+    }
+  }
+
+  private BufferPool pool() {
+    return _persistit.getBufferPool(16384);
+  }
+
+  private Volume volume() throws PersistitException {
+    return _persistit.getVolume(VOLUME_NAME);
+  }
+
+  private int pageTypeOf(final long page) throws PersistitException {
+    final Buffer buffer = pool().get(volume(), page, false, true);
+    try {
+      return buffer.getPageType();
+    } finally {
+      buffer.releaseTouched();
+    }
+  }
+
+  private long rightSiblingOf(final long page) throws PersistitException {
+    final Buffer buffer = pool().get(volume(), page, false, true);
+    try {
+      return buffer.getRightSibling();
+    } finally {
+      buffer.releaseTouched();
+    }
+  }
+
+  /**
+   * Whether the page is currently a data page of the tree, reachable through
+   * a search for its own first key.
+   */
+  private boolean isLiveDataPageOfTree(final Exchange ex, final long page) throws PersistitException {
+    final Buffer buffer = pool().get(volume(), page, false, true);
+    final Key firstKey = new Key(_persistit);
+    try {
+      if (buffer.getPageType() != Buffer.PAGE_TYPE_DATA
+        || buffer.getKeyBlockEnd() <= Buffer.KEY_BLOCK_START) {
+        return false;
+      }
+      buffer.nextKey(firstKey, buffer.toKeyBlock(0));
+    } finally {
+      buffer.releaseTouched();
+    }
+    firstKey.copyTo(ex.getKey());
+    final Buffer copy = ex.fetchBufferCopy(0);
+    return copy != null && copy.getPageAddress() == page;
+  }
+
+  /**
+   * Counts key-pointer entries referencing the page across every index page
+   * of the volume. A consistent B-tree has at most one.
+   */
+  private int countIndexPointersTo(final long page) throws PersistitException {
+    int count = 0;
+    final Volume volume = volume();
+    final long nextAvailable = volume.getStorage().getNextAvailablePage();
+    for (long p = 1; p < nextAvailable; p++) {
+      final Buffer buffer = pool().get(volume, p, false, true);
+      try {
+        if (buffer.isIndexPage()) {
+          for (int at = Buffer.KEY_BLOCK_START; at < buffer.getKeyBlockEnd(); at += Buffer.KEYBLOCK_LENGTH) {
+            if (buffer.getPointer(at) == page) {
+              count++;
+            }
+          }
+        }
+      } finally {
+        buffer.releaseTouched();
+      }
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
Fixes #274.

## Root cause (verified)

When `Exchange#storeInternal` has committed a split, the key-pointer pair for the new right sibling is inserted at the next level by a later iteration of the store loop. If that iteration throws a `RetryException` — in non-MVCC use this only happens on tree height growth with a contended claim upgrade — the handler releases the tree claim entirely before re-acquiring it. In that window a concurrent covering `removeKeyRange` can take the writer claim, unlink the just-split page onto a garbage chain, and retype it `PAGE_TYPE_GARBAGE`. The resumed iteration then inserted the now-stale pointer blindly, planting a dangling index entry to a garbage page.

This matches the CI evidence exactly: `PAGE_TYPE_DATA` is 1 and `PAGE_TYPE_INDEX_MIN` is 2, so the observed `invalid page type 30: should be 2` means searches were descending through a root entry into a garbage-collected **level-1 index page** — the page split off the root whose pending root entry was planted after the page had already been unlinked. The volume stays consistent at rest once later removes delete the entry, which is why `IntegrityCheck` reported 0 faults. (See the correction comment on #274: two residual-mechanism hypotheses from the original analysis did not survive verification; this one did.)

## Fix

- `storeInternal` tracks that a committed split's key-pointer pair is still pending when a retry handler releases the tree claim, and re-validates it under the re-acquired claim at the top of the main loop: a search for the pending key at the child level must land on the pending page itself (via the B-link right-walk, since the page has no parent entry yet). If it lands elsewhere, the page — and its keys — are gone, and the deferred insertion is abandoned.
- `fixIndexHole` is additionally hardened against stale `CleanupIndexHole` actions whose page has been garbage collected and reused as a live indexed page of the same tree at the same level (ABA): both existing guards pass legitimately against the new incarnation, and the action used to perform a parent-level store that is a harmless same-key replace only while every parent entry key equals its page's first key. The repair now runs only when the parent level really has no entry for the page, dropping stale actions outright.

## Tests

New `Bug1017957ResidualTest` covers both deterministically (the original `Bug1017957Test#induceCorruptionByStress` reproduces the race only probabilistically under a 10-second stress):

- `pendingSplitPointerRevalidatedAfterTreeClaimDrop` uses a new `STORE_PENDING_SPLIT` ThreadSequencer schedule to park the writer inside the retry window with the root split committed, runs a covering remove that garbage-collects the pending page, and asserts no index entry points to it, `IntegrityCheck` is clean, and a full traversal does not throw. Without the fix it fails with `No index entry may point to the garbage page expected:<0> but was:<1>`.
- `staleIndexHoleActionOnReusedPageIsDropped` unlinks a page, drives its reuse through the garbage chain, then performs a stale `CleanupIndexHole` against it and asserts the action stores nothing (tree store counter unchanged) and the page keeps exactly one parent entry. Without the fix it fails with `expected:<73> but was:<74>`.

Verified: both new tests fail with the fixes reverted and pass with them; `Bug1017957Test` stress passes with `Total errors 0`; full `persistit/core` suite: 569 tests, 0 failures, 0 errors (5 pre-existing skips).
