### PR TITLE
Fix ReDoS and URL-scheme bypass in bundled marked.js

### DIFF
--- a/commons/rest/openapi-war-overlay/src/main/webapp/openapi/lib/marked.js
+++ b/commons/rest/openapi-war-overlay/src/main/webapp/openapi/lib/marked.js
@@ -2,6 +2,8 @@
  * marked - a markdown parser
  * Copyright (c) 2011-2014, Christopher Jeffrey. (MIT Licensed)
  * https://github.com/chjj/marked
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 ;(function() {
@@ -454,7 +456,11 @@ var inline = {
   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
-  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  // Local ReDoS patch: the alternatives once used [\s\S], which overlaps with
+  // the __ / ** literals, letting a run of those markers be partitioned in
+  // exponentially many ways. Restricting the non-marker branch to [^_] / [^*]
+  // removes the overlap so matching stays linear.
+  em: /^\b_((?:__|[^_])+?)_\b|^\*((?:\*\*|[^*])+?)\*(?!\*)/,
   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
   del: noop,
@@ -868,7 +874,9 @@ Renderer.prototype.link = function(href, title, text) {
     } catch (e) {
       return '';
     }
-    if (prot.indexOf('javascript:') === 0) {
+    // Local patch: also reject data: and vbscript:, not just javascript:.
+    // Any of these schemes can carry executable/script payloads (XSS).
+    if (/^(?:javascript|vbscript|data):/.test(prot)) {
       return '';
     }
   }


### PR DESCRIPTION
## Summary

Closes three CodeQL **high** alerts in the vendored Swagger UI copy of `marked` (`commons/rest/openapi-war-overlay/.../openapi/lib/marked.js`). This is a targeted backport of the relevant upstream security fixes rather than a full library upgrade, chosen to avoid changing the swagger-ui markdown rendering (the bundle has been frozen since 2021 and is not managed by a package manager).

## Changes

- **`js/redos` (#2027, #2028)** — the inline `em` grammar used `[\s\S]` alongside the `__` / `**` literals, so a run of those markers could be partitioned in exponentially many ways (catastrophic backtracking). The non-marker branch is now restricted to `[^_]` / `[^*]`, removing the overlap; matching is linear.
- **`js/incomplete-url-scheme-check` (#2040)** — `Renderer.link` only rejected `javascript:` under `sanitize`. It now also rejects `data:` and `vbscript:`, which can carry script payloads.

## Verification

Node smoke test on the patched file:
- `em` / `strong` / mixed `__`/`_` / link rendering unchanged;
- the previously catastrophic ReDoS inputs finish in < 0.1 ms;
- `javascript:`, `data:`, `vbscript:` links are dropped under `sanitize`, while `http:` still renders.
