### PR TITLE
Harden docbook branding scripts.js (CodeQL high alerts)

### DIFF
--- a/commons/doc-default-branding/src/main/resources/docbkx-stylesheets/bootstrap/scripts.js
+++ b/commons/doc-default-branding/src/main/resources/docbkx-stylesheets/bootstrap/scripts.js
@@ -12,34 +12,49 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 //<![CDATA[
 
 var loadJavaScriptsFN = function () {
     $.ajaxSetup({ cache: true });
-    $.getScript("http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.js", function () { prettyPrint() });
-    $.getScript("http://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js", function () {enableZeroClipboardFN() });
-    $.getScript("http://cdnjs.cloudflare.com/ajax/libs/jquery.colorbox/1.4.33/jquery.colorbox-min.js", function () { enableColorboxFN() });
+    $.getScript("https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.js", function () { prettyPrint() });
+    $.getScript("https://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js", function () {enableZeroClipboardFN() });
+    $.getScript("https://cdnjs.cloudflare.com/ajax/libs/jquery.colorbox/1.4.33/jquery.colorbox-min.js", function () { enableColorboxFN() });
+};
+
+// Escape HTML metacharacters in a text node before it is re-inserted with
+// .html(): .text() returns decoded text, so passing it straight to .html()
+// would reinterpret any &, < or > as markup (CodeQL js/xss-through-dom).
+var escapeHtml = function (text) {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+};
+
+// Escape regex metacharacters so a literal example string is matched literally
+// rather than as a pattern; otherwise the dots in the example host match any
+// character (CodeQL js/incomplete-hostname-regexp).
+var escapeRegExp = function (text) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 };
 
 var wrapConfigurablesFn = function () {
     $('*:contains("https://openam.example.com:8443")').each(function(){
         if($(this).children().length < 1)
             $(this).html(
-                $(this).text().replace(new RegExp("https://openam.example.com:8443", 'g'),'<span class="exampleUrl">https://openam.example.com:8443</span>')
+                escapeHtml($(this).text()).replace(new RegExp(escapeRegExp("https://openam.example.com:8443"), 'g'),'<span class="exampleUrl">https://openam.example.com:8443</span>')
             )
     });
     $('*:contains("amadmin")').each(function(){
         if($(this).children().length < 1)
             $(this).html(
-                $(this).text().replace(new RegExp("amadmin", 'g'),'<span class="exampleAdmin">amadmin</span>')
+                escapeHtml($(this).text()).replace(new RegExp(escapeRegExp("amadmin"), 'g'),'<span class="exampleAdmin">amadmin</span>')
             )
     });
     $('*:contains("iPlanetDirectoryPro")').each(function(){
         if($(this).children().length < 1)
             $(this).html(
-                $(this).text().replace(new RegExp("iPlanetDirectoryPro", 'g'),'<span class="exampleSsoCookieName">iPlanetDirectoryPro</span>')
+                escapeHtml($(this).text()).replace(new RegExp(escapeRegExp("iPlanetDirectoryPro"), 'g'),'<span class="exampleSsoCookieName">iPlanetDirectoryPro</span>')
             )
     });
 };


### PR DESCRIPTION
## Summary

Fixes all high-severity CodeQL alerts in the docbook branding stylesheet `commons/doc-default-branding/.../docbkx-stylesheets/bootstrap/scripts.js` (a generated-documentation asset). Six alerts across three rules, all in this one file.

## Changes

- **`js/insecure-download` (#2031, #2032, #2033)** — three `$.getScript()` calls fetched executable JavaScript from `cdnjs.cloudflare.com` over plain HTTP, which is open to man-in-the-middle tampering. Switched to HTTPS; cdnjs serves the same paths over TLS.
- **`js/xss-through-dom` (#2034, #2035, #2036)** — `wrapConfigurablesFn` read an element's text with `.text()` and re-inserted it with `.html()`, so any `&`, `<` or `>` in the text was reinterpreted as markup. The text is now passed through a small `escapeHtml()` helper before the example strings are wrapped.
- **`js/incomplete-hostname-regexp` (#2039)** — the example host was used directly as a `RegExp`, so its dots matched any character. The pattern is now built through an `escapeRegExp()` helper so the literal string is matched literally.

## Verification

Node smoke test on the patched file:
- the file parses;
- HTML metacharacters (`<b>`, `<script>`, `&`) in the source text are escaped;
- the example strings are still wrapped in their styled spans (behaviour preserved);
- the escaped host pattern no longer matches unrelated hosts (e.g. `openamXexampleYcom`).
