### PR TITLE
Escape all quotes in UI helpers (CodeQL incomplete-sanitization)

### DIFF
--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -300,7 +301,7 @@ define([
     Handlebars.registerHelper("staticSelect", function(value, options){
         var selected = $("<select />").html(options.fn(this));
         if (typeof value !== "undefined" && value !== null) {
-            selected.find("[value=\'" + value.toString().replace("'", "\\'") + "\']").attr({"selected":"selected"});
+            selected.find("[value=\'" + value.toString().replace(/'/g, "\\'") + "\']").attr({"selected":"selected"});
         }
         return selected.html();
     });

--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
@@ -301,7 +301,8 @@ define([
     Handlebars.registerHelper("staticSelect", function(value, options){
         var selected = $("<select />").html(options.fn(this));
         if (typeof value !== "undefined" && value !== null) {
-            selected.find("[value=\'" + value.toString().replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "\']").attr({"selected":"selected"});
+            var escaped = value.toString().replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+            selected.find("[value=\'" + escaped + "\']").attr({"selected":"selected"});
         }
         return selected.html();
     });

--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
@@ -301,7 +301,7 @@ define([
     Handlebars.registerHelper("staticSelect", function(value, options){
         var selected = $("<select />").html(options.fn(this));
         if (typeof value !== "undefined" && value !== null) {
-            selected.find("[value=\'" + value.toString().replace(/'/g, "\\'") + "\']").attr({"selected":"selected"});
+            selected.find("[value=\'" + value.toString().replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "\']").attr({"selected":"selected"});
         }
         return selected.html();
     });

--- a/ui/user/src/main/js/org/forgerock/commons/ui/user/anonymousProcess/AnonymousProcessView.js
+++ b/ui/user/src/main/js/org/forgerock/commons/ui/user/anonymousProcess/AnonymousProcessView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -51,7 +52,7 @@ define([
             node = $(basicNode);
 
         if (node.hasClass("filter-value") && node.val().length > 0) {
-            return node.attr('name') + ' eq "' + node.val().replace('"', '\\"') + '"';
+            return node.attr('name') + ' eq "' + node.val().replace(/"/g, '\\"') + '"';
         } else if (node.hasClass("filter-group")) {
             groupValues = _.chain(node.find(">.form-group>.filter-value, >.filter-group"))
                            .map(walkTreeForFilterStrings)

--- a/ui/user/src/main/js/org/forgerock/commons/ui/user/anonymousProcess/AnonymousProcessView.js
+++ b/ui/user/src/main/js/org/forgerock/commons/ui/user/anonymousProcess/AnonymousProcessView.js
@@ -52,7 +52,7 @@ define([
             node = $(basicNode);
 
         if (node.hasClass("filter-value") && node.val().length > 0) {
-            return node.attr('name') + ' eq "' + node.val().replace(/"/g, '\\"') + '"';
+            return node.attr('name') + ' eq "' + node.val().replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
         } else if (node.hasClass("filter-group")) {
             groupValues = _.chain(node.find(">.form-group>.filter-value, >.filter-group"))
                            .map(walkTreeForFilterStrings)


### PR DESCRIPTION
## Summary

Fixes two CodeQL **high** `js/incomplete-sanitization` alerts. Both call sites escaped a quote with `String.replace()` using a plain-string first argument, which replaces only the **first** match, leaving later quotes unescaped.

## Changes

- **`ui/commons/.../util/UIUtils.js` (#2029)** — the `staticSelect` Handlebars helper splices a value into a jQuery attribute selector and escaped single quotes with `replace("'", "\\'")`. Changed to escape every single quote.
- **`ui/user/.../anonymousProcess/AnonymousProcessView.js` (#2030)** — `walkTreeForFilterStrings` builds a filter query and escaped double quotes with `replace('"', '\\"')`. Changed to escape every double quote.

## Round 2: escape backslashes first (#2080, #2081)

CodeQL then flagged the fix itself with `js/incomplete-string-escaping`: escaping only the quote is insufficient, because an input backslash immediately before a quote swallows the added escape (`evil\'` → `evil\\'`, quote live again). Both call sites now double backslashes before escaping quotes:

- `UIUtils.js` — `replace(/\\/g, "\\\\").replace(/'/g, "\\'")`
- `AnonymousProcessView.js` — `replace(/\\/g, '\\\\').replace(/"/g, '\\"')`

## Verification

- Both files pass `node --check`.
- Logic check: `evil\'break` previously escaped to `evil\\'break` (backslash swallows the escape, quote live); now escapes to `evil\\\'break` (quote inert). Multi-quote inputs escape every occurrence.
