### PR TITLE
Guard OAuth return pages against prototype pollution

### DIFF
--- a/ui/commons/src/main/resources/oauthReturn.html
+++ b/ui/commons/src/main/resources/oauthReturn.html
@@ -1,3 +1,6 @@
+<!-- Copyright 2015 ForgeRock AS.
+	License terms: https://forgerock.org/cddlv1-0/
+	Portions Copyrighted 2026 3A Systems, LLC -->
 <script>
 (function () {
     /**
@@ -16,7 +19,11 @@
     */
     var queryParams = window.location.search.replace("?", "").split("&").reduce(function (map, item) {
             var parts = item.split("=");
-            map[parts[0]] = decodeURIComponent(parts[1]);
+            // Guard against prototype pollution: never let a user-controlled query
+            // parameter name overwrite __proto__/constructor/prototype (CWE-1321).
+            if (parts[0] !== "__proto__" && parts[0] !== "constructor" && parts[0] !== "prototype") {
+                map[parts[0]] = decodeURIComponent(parts[1]);
+            }
             return map;
         }, {});
 

--- a/ui/commons/src/main/resources/oauthReturn.html
+++ b/ui/commons/src/main/resources/oauthReturn.html
@@ -17,19 +17,22 @@
         This step is necessary because IDPs do not allow you to specify a redirect URI with
         a hash fragment; this file works around that requirement.
     */
-    var queryParams = window.location.search.replace("?", "").split("&").reduce(function (map, item) {
+    // Look up a single query parameter by name. Reading only the known
+    // parameters avoids writing map entries keyed by user input (CWE-1321).
+    function getQueryParam(name) {
+        var value;
+        window.location.search.replace("?", "").split("&").forEach(function (item) {
             var parts = item.split("=");
-            // Guard against prototype pollution: never let a user-controlled query
-            // parameter name overwrite __proto__/constructor/prototype (CWE-1321).
-            if (parts[0] !== "__proto__" && parts[0] !== "constructor" && parts[0] !== "prototype") {
-                map[parts[0]] = decodeURIComponent(parts[1]);
+            if (parts[0] === name) {
+                value = decodeURIComponent(parts[1]);
             }
-            return map;
-        }, {});
+        });
+        return value;
+    }
 
     window.location.href = window.location.href
-        // queryParams.state is expected to be the URL fragment plus any other
+        // the "state" parameter is expected to be the URL fragment plus any other
         // details necessary to resume the oauth process
-        .replace(/oauthReturn\.html.*/, "#" + queryParams.state + "&code=" + queryParams.code);
+        .replace(/oauthReturn\.html.*/, "#" + getQueryParam("state") + "&code=" + getQueryParam("code"));
 }())
 </script>

--- a/ui/mock/src/main/resources/mockOAuthAuthorization.html
+++ b/ui/mock/src/main/resources/mockOAuthAuthorization.html
@@ -1,5 +1,8 @@
 
 
+<!-- Copyright 2015 ForgeRock AS.
+	License terms: https://forgerock.org/cddlv1-0/
+	Portions Copyrighted 2026 3A Systems, LLC -->
 <body>
 
 Mock OAuth Provider redirecting in <span id="countDown"></span>....
@@ -11,7 +14,11 @@ Mock OAuth Provider redirecting in <span id="countDown"></span>....
 (function () {
     var queryParams = window.location.search.replace("?", "").split("&").reduce(function (map, item) {
             var parts = item.split("=");
-            map[parts[0]] = decodeURIComponent(parts[1]);
+            // Guard against prototype pollution: never let a user-controlled query
+            // parameter name overwrite __proto__/constructor/prototype (CWE-1321).
+            if (parts[0] !== "__proto__" && parts[0] !== "constructor" && parts[0] !== "prototype") {
+                map[parts[0]] = decodeURIComponent(parts[1]);
+            }
             return map;
         }, {}),
         countDown = 3;

--- a/ui/mock/src/main/resources/mockOAuthAuthorization.html
+++ b/ui/mock/src/main/resources/mockOAuthAuthorization.html
@@ -12,22 +12,26 @@ Mock OAuth Provider redirecting in <span id="countDown"></span>....
 
 <script>
 (function () {
-    var queryParams = window.location.search.replace("?", "").split("&").reduce(function (map, item) {
+    // Look up a single query parameter by name. Reading only the known
+    // parameters avoids writing map entries keyed by user input (CWE-1321).
+    function getQueryParam(name) {
+        var value;
+        window.location.search.replace("?", "").split("&").forEach(function (item) {
             var parts = item.split("=");
-            // Guard against prototype pollution: never let a user-controlled query
-            // parameter name overwrite __proto__/constructor/prototype (CWE-1321).
-            if (parts[0] !== "__proto__" && parts[0] !== "constructor" && parts[0] !== "prototype") {
-                map[parts[0]] = decodeURIComponent(parts[1]);
+            if (parts[0] === name) {
+                value = decodeURIComponent(parts[1]);
             }
-            return map;
-        }, {}),
-        countDown = 3;
+        });
+        return value;
+    }
+
+    var countDown = 3;
 
     setInterval(function () {
         document.getElementById("countDown").innerHTML = countDown;
         countDown--;
         if (countDown <= 0) {
-            window.location.href=queryParams.redirect_uri + "?code=randomAccessCode&state=" + encodeURIComponent(queryParams.state);
+            window.location.href=getQueryParam("redirect_uri") + "?code=randomAccessCode&state=" + encodeURIComponent(getQueryParam("state"));
         }
     }, 1000);
     document.getElementById("countDown").innerHTML = countDown+1;

--- a/ui/mock/src/main/resources/mockOAuthAuthorization.html
+++ b/ui/mock/src/main/resources/mockOAuthAuthorization.html
@@ -30,12 +30,20 @@ Mock OAuth Provider redirecting in <span id="countDown"></span>....
     // document and rebuild it on our own origin. Cross-origin targets and
     // non-http schemes (e.g. javascript:) are rejected (CWE-79, CWE-601).
     function getSafeRedirectUri() {
-        var resolver = document.createElement("a");
-        resolver.href = getQueryParam("redirect_uri");
-        if (resolver.protocol !== window.location.protocol || resolver.host !== window.location.host) {
+        var redirectUri = getQueryParam("redirect_uri");
+        if (!redirectUri) {
             return undefined;
         }
-        return window.location.protocol + "//" + window.location.host + resolver.pathname;
+        var url;
+        try {
+            url = new URL(redirectUri, window.location.href);
+        } catch (e) {
+            return undefined;
+        }
+        if (url.origin !== window.location.origin) {
+            return undefined;
+        }
+        return window.location.protocol + "//" + window.location.host + url.pathname;
     }
 
     var countDown = 3;

--- a/ui/mock/src/main/resources/mockOAuthAuthorization.html
+++ b/ui/mock/src/main/resources/mockOAuthAuthorization.html
@@ -25,13 +25,32 @@ Mock OAuth Provider redirecting in <span id="countDown"></span>....
         return value;
     }
 
+    // The mock provider only ever redirects back into the application that
+    // initiated the flow, so resolve redirect_uri against the current
+    // document and rebuild it on our own origin. Cross-origin targets and
+    // non-http schemes (e.g. javascript:) are rejected (CWE-79, CWE-601).
+    function getSafeRedirectUri() {
+        var resolver = document.createElement("a");
+        resolver.href = getQueryParam("redirect_uri");
+        if (resolver.protocol !== window.location.protocol || resolver.host !== window.location.host) {
+            return undefined;
+        }
+        return window.location.protocol + "//" + window.location.host + resolver.pathname;
+    }
+
     var countDown = 3;
 
-    setInterval(function () {
+    var timer = setInterval(function () {
         document.getElementById("countDown").innerHTML = countDown;
         countDown--;
         if (countDown <= 0) {
-            window.location.href=getQueryParam("redirect_uri") + "?code=randomAccessCode&state=" + encodeURIComponent(getQueryParam("state"));
+            clearInterval(timer);
+            var redirectUri = getSafeRedirectUri();
+            if (redirectUri) {
+                window.location.href=redirectUri + "?code=randomAccessCode&state=" + encodeURIComponent(getQueryParam("state"));
+            } else {
+                document.body.innerHTML = "Invalid redirect_uri";
+            }
         }
     }, 1000);
     document.getElementById("countDown").innerHTML = countDown+1;

--- a/ui/mock/src/main/resources/mockOAuthAuthorization.html
+++ b/ui/mock/src/main/resources/mockOAuthAuthorization.html
@@ -43,7 +43,9 @@ Mock OAuth Provider redirecting in <span id="countDown"></span>....
         if (url.origin !== window.location.origin) {
             return undefined;
         }
-        return window.location.protocol + "//" + window.location.host + url.pathname;
+        // Any query or fragment on the incoming redirect_uri is dropped
+        // deliberately: the caller appends its own ?code=...&state=... below.
+        return url.origin + url.pathname;
     }
 
     var countDown = 3;


### PR DESCRIPTION
## Summary

Fixes the CodeQL **high** `js/remote-property-injection` alerts on the two OAuth return pages (originally #2041 / #2042, re-reported as #2082 / #2083), and — on the mock provider page — the `js/xss` / `js/client-side-unvalidated-url-redirection` alerts (#2085–#2088).

Both pages built a `queryParams` object by writing `map[name] = value` for every URL parameter, where the parameter name is user-controlled — the pattern CodeQL flags as a user-keyed property write (CWE-1321). There is no known exploit path in the old code: every written value is a string from `decodeURIComponent`, and the `__proto__` setter silently ignores non-object values, so `Object.prototype` could not actually be polluted; the only observable effect was shadowing names like `constructor` on a local throwaway map that was read through its three known keys only. The rewrite removes the flagged pattern rather than closing a live vulnerability.

The mock page fix goes further: it also stops an open redirect (CWE-601) / DOM XSS (CWE-79), which *was* a real (test-scope) flaw — see below.

## Changes

- **`ui/commons/.../oauthReturn.html`** and **`ui/mock/.../mockOAuthAuthorization.html`** — replace the query-parameter map with a `getQueryParam(name)` helper that scans the query string for a single known name. The pages read only the parameters they actually use (`state`, `code`, `redirect_uri`), so no property is ever written under a user-controlled name and the alert source is gone entirely. A side benefit: the old code decoded every parameter, so a malformed unrelated one (`?junk=%&state=ok`) threw `URIError` and killed the page; the helper decodes only the requested parameter.
- **`mockOAuthAuthorization.html`** additionally gains an open-redirect / XSS fix: the page previously navigated to the user-supplied `redirect_uri` verbatim, accepting `javascript:` and cross-origin targets. The new `getSafeRedirectUri()` resolves `redirect_uri` with the `URL` API against the current document, rejects anything not on the page's own origin, and rebuilds the target as `origin + pathname` (any query/fragment on the incoming value is dropped deliberately — the caller appends its own `?code=…&state=…`). The countdown interval is now also cleared once the redirect fires, fixing a pre-existing timer leak.

An earlier revision of this PR kept the map and skipped the reserved names `__proto__` / `constructor` / `prototype`; CodeQL does not recognize that blocklist as a sanitizer (the query flags any user-keyed property write, not just prototype pollution), so the map was removed altogether.

## Verification

Node logic test of the helpers:
- normal parsing preserved — `state` / `code` / `redirect_uri` are read correctly, including the encoded-fragment example from the `oauthReturn.html` doc comment;
- duplicate parameters keep last-wins semantics and a missing parameter yields `undefined`, matching the old map lookup;
- the origin check rejects `javascript:alert(1)`, `data:` URIs, `//evil.com/x`, and `http://localhost:8080@evil.com/x`, while same-origin absolute and relative paths rebuild unchanged.
