### PR TITLE
Fix useless regex escapes in ValidatorsUtils namePattern

### DIFF
--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/ValidatorsUtils.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/ValidatorsUtils.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -25,7 +26,7 @@ define([
         "\u00F9\u00C1\u00C9\u00CD\u00D3\u00DA\u00DD\u00E1\u00E9\u00ED\u00F3\u00FA\u00FD\u00C2\u00CA\u00CE\u00D4" +
         "\u00DB\u00E2\u00EA\u00EE\u00F4\u00FB\u00C3\u00D1\u00D5\u00E3\u00F1\u00F5\u00C4\u00CB\u00CF\u00D6\u00DC" +
         "\u0178\u00E4\u00EB\u00EF\u00F6\u00FC\u0178\u00A1\u00BF\u00E7\u00C7\u0152\u0153\u00DF\u00D8\u00F8\u00C5" +
-        "\u00E5\u00C6\u00E6\u00DE\u00FE\u00D0\u00F0\-\s])+$");
+        "\u00E5\u00C6\u00E6\u00DE\u00FE\u00D0\u00F0\\s-])+$");
     obj.phonePattern = /^\+?([0-9\- \(\)])*$/;
     obj.emailPattern = /^([A-Za-z0-9_\-\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,4})$/;
 


### PR DESCRIPTION
## Summary

Fixes two CodeQL **high** `js/useless-regexp-character-escape` alerts (#2037, #2038) in `ValidatorsUtils.js`.

`namePattern` is built from a **string** via `new RegExp("...")`, so the string parser consumed the backslashes before the regex ever saw them: `"\-"` collapsed to `"-"` and `"\s"` collapsed to `"s"`.

## What this actually fixes

The escapes were not merely cosmetic. Because the trailing `"\-"` became a bare `"-"`, it formed a **reversed range** with the preceding character `U+00F0` (`ð-s`), so the pattern failed to compile at all:

```
SyntaxError: Invalid regular expression: Range out of order in character class
```

The fix escapes the whitespace class as `"\\s"` (so the regex receives `\s`) and moves the literal hyphen to the end of the character class (where it needs no escape and cannot start a range).

## Verification

Reconstructing the exact string from the file and building the `RegExp`:
- **before:** throws `Range out of order in character class`;
- **after:** compiles, and matches names with spaces and hyphens — `John`, `O'Brien`, `Anne-Marie`, `John Smith` all pass; `\s` and `-` are honoured.

Scope note: only the two flagged escapes were changed. The broad `'-ą` range earlier in the class was not flagged by CodeQL and is left untouched.
