### PR TITLE
Harden GitHub Actions workflows (CodeQL medium alerts)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
+permissions:
+  contents: read
 jobs:
   deploy:
     name: Maven deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
+permissions:
+  contents: write
 jobs:
   release:
     name: Maven release
@@ -63,7 +65,7 @@ jobs:
         if: ${{ env.MAVEN_USERNAME!='' && env.MAVEN_PASSWORD!='' }}
         run: mvn --batch-mode -Darguments="-Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}" -DsignTag=true -DtagNameFormat="${{ github.event.inputs.releaseVersion }}" -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} release:prepare release:perform --file pom.xml
       - name: Release on GitHub
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ github.event.inputs.releaseVersion }}
           tag_name: ${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
Fixes the medium-severity CodeQL "GitHub Actions" code-scanning alerts.

### Changes
- **`actions/missing-workflow-permissions`** (build.yml, deploy.yml, release.yml): add a minimal top-level `permissions` block instead of relying on the default broad `GITHUB_TOKEN` scope.
  - `build.yml` → `contents: read`
  - `deploy.yml` → `contents: read`
  - `release.yml` → `contents: write` (required for the `release:prepare` git push and the GitHub Release creation)
- **`actions/unpinned-tag`** (release.yml): pin `softprops/action-gh-release` to a full commit SHA (`3d0d988`, = `v3.0.2`) instead of the movable `@v3` tag.

### Not changed
- **`actions/untrusted-checkout/medium`** (deploy.yml checkout) was dismissed as a false positive: `on.workflow_run.branches` is limited to `sustaining/2.4.x`/`master` and the job requires a `push` trigger, so fork PRs cannot reach it and `head_branch` always resolves to trusted code.