### PR TITLE
Fix potential unreleased lock in ScriptRegistryImpl (CodeQL java/unreleased-lock)

### DIFF
--- a/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
@@ -69,6 +69,7 @@ import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -697,11 +698,12 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
             } else if (unit instanceof SourceContainer) {
                 SourceContainer container = (SourceContainer) unit;
 
-                sourceCacheLock.writeLock().lock();
+                final Lock writeLock = sourceCacheLock.writeLock();
+                writeLock.lock();
                 try {
                     sourceCache.put(unit.getName(), container);
                 } finally {
-                    sourceCacheLock.writeLock().unlock();
+                    writeLock.unlock();
                 }
 
                 for (LibraryRecord cacheRecord : cache.values()) {


### PR DESCRIPTION
Fixes the medium-severity CodeQL alert `java/unreleased-lock` in `ScriptRegistryImpl.addSourceUnit` (script/common).

### Root cause
The write-lock block already uses a correct `lock(); try { … } finally { unlock(); }` shape, but it acquires and releases through two separate `sourceCacheLock.writeLock()` getter calls. Inside the surrounding `try/catch`, CodeQL cannot prove both getter calls return the same `Lock` instance and reports a possible unreleased lock. (This is the only one of four lock blocks in the file that is nested in an outer try/catch, which is why it is the only one flagged.)

### Fix
Hoist the lock into a local variable so `lock()` and `unlock()` operate on the same reference — the canonical remediation for this rule:

```java
final Lock writeLock = sourceCacheLock.writeLock();
writeLock.lock();
try {
    sourceCache.put(unit.getName(), container);
} finally {
    writeLock.unlock();
}
```

No behavior change. `mvn -pl script/common -am compile` passes.