### PR TITLE
[#286] Fix MVV marked-version corruption after interrupted prune

### DIFF
--- a/persistit/core/src/main/java/com/persistit/MVV.java
+++ b/persistit/core/src/main/java/com/persistit/MVV.java
@@ -171,7 +171,7 @@ class MVV {
             return overheadLength(2) + targetLength + newVersionLength;
         } else {
             int offset = targetOffset + 1;
-            while (offset < targetLength) {
+            while (offset < targetOffset + targetLength) {
                 final long version = getVersion(target, offset);
                 final int valueLength = getLength(target, offset);
                 offset += LENGTH_PER_VERSION + valueLength;
@@ -295,7 +295,7 @@ class MVV {
          * Value previously existed as a primordial value. Result will be an MVV
          * with two versions.
          */
-        else if (target[0] != TYPE_MVV_BYTE) {
+        else if (target[targetOffset] != TYPE_MVV_BYTE) {
             assertCapacity(targetLimit, targetOffset + sourceLength + targetLength + overheadLength(2));
             // Promote to MVV, shift existing down for header
             System.arraycopy(target, to, target, to + LENGTH_TYPE_MVV + LENGTH_PER_VERSION, targetLength);
@@ -484,7 +484,13 @@ class MVV {
                     }
                 }
                 from += vlength + LENGTH_PER_VERSION;
-                if (from > offset + length) {
+                if (from != offset + length && from + LENGTH_PER_VERSION > offset + length) {
+                    /*
+                     * A version must either end exactly at the region end or
+                     * leave room for at least one more version header. Anything
+                     * else is a misaligned traversal; reject it before the next
+                     * iteration reads or marks outside the MVV region.
+                     */
                     throw new CorruptValueException("MVV Value is corrupt at index: " + from);
                 }
             }
@@ -578,17 +584,21 @@ class MVV {
             throw new PersistitInterruptedException(ie);
         } finally {
             /*
-             * Make sure all marks are removed even if this method exits via an
-             * Exception.
+             * Remove marks left by pass 1 even when this method exits via an
+             * exception: a mark left in a live page is read back as part of
+             * the version length and corrupts the MVV (issue #286). Mirrors
+             * pass 1 - same advance, same guard - so it touches exactly the
+             * indices that pass could have marked, and nothing else. A
+             * zero-length version is legal, hence no break on vlength == 0.
+             * The array-end bound covers pass 1's unguarded first iteration.
              */
             if (marked > 0) {
                 int index = offset + 1;
-                while (index < length) {
+                while (index + LENGTH_PER_VERSION <= bytes.length) {
                     final int vlength = getLength(bytes, index);
-                    Debug.$assert0.t(vlength + index + LENGTH_PER_VERSION <= offset + length);
                     unmark(bytes, index);
                     index += vlength + LENGTH_PER_VERSION;
-                    if (vlength <= 0) {
+                    if (index + LENGTH_PER_VERSION > offset + length) {
                         break;
                     }
                 }
@@ -663,8 +673,12 @@ class MVV {
      *         if no value was copied.
      * @throws IllegalArgumentException
      *             If the target array is too small to hold the value
+     * @throws CorruptValueException
+     *             If a version header or value extends past
+     *             <code>sourceLength</code>
      */
-    public static int fetchVersion(final byte[] source, final int sourceLength, final long version, final byte[] target) {
+    public static int fetchVersion(final byte[] source, final int sourceLength, final long version, final byte[] target)
+            throws CorruptValueException {
         int offset = 0;
         int length = VERSION_NOT_FOUND;
 
@@ -673,9 +687,17 @@ class MVV {
         } else if (sourceLength > 0 && source[0] == TYPE_MVV_BYTE) {
             offset = 1;
             while (offset < sourceLength) {
-                final long curVersion = Util.getLong(source, offset);
-                final int curLength = Util.getShort(source, offset + LENGTH_VERSION);
+                if (offset + LENGTH_PER_VERSION > sourceLength) {
+                    throw new CorruptValueException("MVV version header at offset " + offset
+                            + " extends past length " + sourceLength);
+                }
+                final long curVersion = getVersion(source, offset);
+                final int curLength = getLength(source, offset);
                 offset += LENGTH_PER_VERSION;
+                if (curLength > sourceLength - offset) {
+                    throw new CorruptValueException("MVV version value at offset " + offset + " with length "
+                            + curLength + " extends past length " + sourceLength);
+                }
                 if (curVersion == version) {
                     length = curLength;
                     break;
@@ -739,15 +761,29 @@ class MVV {
         } else if (source[sourceOffset] != TYPE_MVV_BYTE) {
             visitor.sawVersion(PRIMORDIAL_VALUE_VERSION, sourceOffset, sourceLength);
         } else {
+            final int end = sourceOffset + sourceLength;
             int offset = sourceOffset + 1;
-            while (offset < sourceOffset + sourceLength) {
-                final long version = Util.getLong(source, offset);
-                final int valueLength = Util.getShort(source, offset + LENGTH_VERSION);
+            while (offset < end) {
+                if (offset + LENGTH_PER_VERSION > end) {
+                    throw new CorruptValueException("MVV version header at offset " + offset
+                            + " extends past offset/length=" + sourceOffset + "/" + sourceLength);
+                }
+                final long version = getVersion(source, offset);
+                final int valueLength = getLength(source, offset);
                 offset += LENGTH_PER_VERSION;
+                if (valueLength > end - offset) {
+                    throw new CorruptValueException("MVV version value at offset " + offset + " with length "
+                            + valueLength + " extends past offset/length=" + sourceOffset + "/" + sourceLength);
+                }
                 visitor.sawVersion(version, offset, valueLength);
                 offset += valueLength;
             }
-            if (offset != sourceOffset + sourceLength) {
+            /*
+             * Defensive only: the per-version guards above make this
+             * unreachable (the loop can only exit with offset == end). Kept in
+             * case the traversal logic changes.
+             */
+            if (offset != end) {
                 throw new CorruptValueException("invalid length in MVV at offset/length=" + sourceOffset + "/"
                         + sourceLength);
             }
@@ -773,14 +809,20 @@ class MVV {
      *         if no value was copied.
      * @throws IllegalArgumentException
      *             If the target array is too small to hold the value
+     * @throws CorruptValueException
+     *             If the stored value extends past <code>sourceLength</code>
      */
     public static int fetchVersionByOffset(final byte[] source, final int sourceLength, final int offset,
-            final byte[] target) {
+            final byte[] target) throws CorruptValueException {
         if (offset < 0 || (offset > 0 && offset > sourceLength)) {
             throw new IllegalArgumentException("Offset out of range: " + offset);
         }
-        final int length = (offset == 0) ? sourceLength : Util.getShort(source, offset - LENGTH_VALUE_LENGTH);
+        final int length = (offset == 0) ? sourceLength : getLength(source, offset - LENGTH_PER_VERSION);
         if (length > 0) {
+            if (length > sourceLength - offset) {
+                throw new CorruptValueException("MVV version value at offset " + offset + " with length " + length
+                        + " extends past length " + sourceLength);
+            }
             assertCapacity(target.length, length);
             System.arraycopy(source, offset, target, 0, length);
         }

--- a/persistit/core/src/test/java/com/persistit/MVVTest.java
+++ b/persistit/core/src/test/java/com/persistit/MVVTest.java
@@ -12,15 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.persistit;
 
+import com.persistit.exception.CorruptValueException;
 import com.persistit.exception.PersistitException;
 import com.persistit.util.Util;
 import junit.framework.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -30,6 +34,7 @@ import static com.persistit.MVV.TYPE_MVV;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MVVTest {
     @Test
@@ -321,7 +326,7 @@ public class MVVTest {
     }
 
     @Test
-    public void fetchVersionFromUnused() {
+    public void fetchVersionFromUnused() throws PersistitException {
         final long vh = 10;
         final byte[] source = {};
         final byte[] target = {};
@@ -329,7 +334,7 @@ public class MVVTest {
     }
 
     @Test
-    public void fetchVersionFromUndefined() {
+    public void fetchVersionFromUndefined() throws PersistitException {
         final long vh = 10;
         final byte[] source = {};
         final byte[] target = {};
@@ -337,7 +342,7 @@ public class MVVTest {
     }
 
     @Test
-    public void fetchVersionFromPrimordial() {
+    public void fetchVersionFromPrimordial() throws PersistitException {
         final long vh = 10;
         final byte[] source = { 0xA, 0xB, 0xC };
         final byte[] target = {};
@@ -345,7 +350,7 @@ public class MVVTest {
     }
 
     @Test
-    public void fetchVersionFromExistingNoFound() {
+    public void fetchVersionFromExistingNoFound() throws PersistitException {
         final long vh = 10;
         final byte[] source = { (byte) TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 2,
                 0, 2, 0xD, 0xE };
@@ -354,7 +359,7 @@ public class MVVTest {
     }
 
     @Test
-    public void fetchVersionFromExisting() {
+    public void fetchVersionFromExisting() throws PersistitException {
         final long vh = 10;
         final byte[] source = { (byte) TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 10, 0, 2, 0xA, 0xB, 0, 0, 0, 0, 0, 0, 0, 11, 0,
                 3, 0xB, 0xC };
@@ -366,7 +371,7 @@ public class MVVTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fetchVersionFromExistingOverCapacity() {
+    public void fetchVersionFromExistingOverCapacity() throws PersistitException {
         final long vh = 10;
         final byte[] source = { (byte) TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 11, 0, 5, 0x1, 0x2, 0x3, 0x4, 0x5, 0, 0, 0, 0, 0,
                 0, 0, 9, 0, 1, 0xA, 0, 0, 0, 0, 0, 0, 0, 10, 0, 3, 0xB, 0xC, 0xD };
@@ -429,21 +434,21 @@ public class MVVTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fetchByOffsetNegative() {
+    public void fetchByOffsetNegative() throws PersistitException {
         final byte[] source = {};
         final byte[] target = new byte[10];
         MVV.fetchVersionByOffset(source, source.length, -1, target);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fetchByOffsetTooLarge() {
+    public void fetchByOffsetTooLarge() throws PersistitException {
         final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 0xA, 0xB, 0xC);
         final byte[] target = new byte[10];
         MVV.fetchVersionByOffset(source, source.length, source.length + 1, target);
     }
 
     @Test
-    public void storeAndFetchVersionMany() {
+    public void storeAndFetchVersionMany() throws PersistitException {
         final int VERSION_COUNT = 10;
         final int versions[] = new int[VERSION_COUNT];
         final byte sources[][] = new byte[VERSION_COUNT][];
@@ -478,6 +483,145 @@ public class MVVTest {
         final byte[] target = new byte[LENGTH + 100];
         final byte[] source = new byte[LENGTH];
         MVV.storeVersion(target, 0, 0, target.length, VERSION, source, 0, source.length);
+    }
+
+    //
+    // Issue #286: a version left in the marked state (e.g. by a prune that was
+    // interrupted mid-way) must still be readable. The length accessors used
+    // by the fetch paths formerly read the length field signed and with the
+    // mark bit included, driving the scan offset negative and throwing
+    // ArrayIndexOutOfBoundsException.
+    //
+
+    @Test
+    public void visitMarkedVersion() throws PersistitException {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 1, 0, 3, 0xA, 0xB, 0xC, 0, 0, 0, 0, 0, 0, 0, 2,
+                0, 2, 0xD, 0xE);
+        MVV.mark(source, 1);
+        final TestVisitor visitor = new TestVisitor();
+        MVV.visitAllVersions(visitor, source, 0, source.length);
+        assertTrue(visitor.initCalled);
+        assertEquals(newVisitorMap(1, 3, 11, 2, 2, 24), visitor.versions);
+    }
+
+    @Test
+    public void fetchMarkedVersion() throws PersistitException {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 10, 0, 2, 0xA, 0xB, 0, 0, 0, 0, 0, 0, 0, 11, 0,
+                3, 0xC, 0xD, 0xE);
+        MVV.mark(source, 1);
+        MVV.mark(source, 13);
+        final byte[] target = new byte[20];
+        assertEquals(2, MVV.fetchVersion(source, source.length, 10, target));
+        assertArrayEqualsLen(newArray(0xA, 0xB), target, 2);
+        assertEquals(3, MVV.fetchVersion(source, source.length, 11, target));
+        assertArrayEqualsLen(newArray(0xC, 0xD, 0xE), target, 3);
+    }
+
+    @Test
+    public void fetchByOffsetMarkedVersion() throws PersistitException {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 10, 0, 2, 0xA, 0xB, 0, 0, 0, 0, 0, 0, 0, 11, 0,
+                3, 0xC, 0xD, 0xE);
+        MVV.mark(source, 1);
+        final byte[] target = new byte[20];
+        assertEquals(2, MVV.fetchVersionByOffset(source, source.length, 11, target));
+        assertArrayEqualsLen(newArray(0xA, 0xB), target, 2);
+    }
+
+    @Test(expected = CorruptValueException.class)
+    public void visitTruncatedHeaderThrows() throws PersistitException {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0);
+        MVV.visitAllVersions(new TestVisitor(), source, 0, source.length);
+    }
+
+    /**
+     * The old code also threw CorruptValueException here (from the trailing
+     * length check), but only after handing the visitor an out-of-bounds
+     * version — which Exchange.MvvVisitor would record and fetchVersionByOffset
+     * would then copy. The fix must throw before the visitor sees it.
+     */
+    @Test
+    public void visitOverrunningLengthThrows() throws PersistitException {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 1, 0, 50, 0xA, 0xB, 0xC);
+        final TestVisitor visitor = new TestVisitor();
+        try {
+            MVV.visitAllVersions(visitor, source, 0, source.length);
+            fail("expected CorruptValueException");
+        } catch (final CorruptValueException expected) {
+        }
+        assertTrue("visitor must not see an out-of-bounds version", visitor.versions.isEmpty());
+    }
+
+    /**
+     * Issue #286: when prune exits via an exception after its first pass has
+     * marked versions (e.g. interrupted while resolving a commit status, or a
+     * CorruptValueException), the finally-block safety net must remove the
+     * marks. Its loop bound was wrong for a non-zero offset — exactly the
+     * in-page pruning case — leaving mark bits behind in the live buffer page.
+     */
+    @Test
+    public void pruneExceptionUnmarksVersionsAtNonZeroOffset() throws Exception {
+        final TimestampAllocator tsa = new TimestampAllocator();
+        final TransactionIndex ti = new TransactionIndex(tsa, 1);
+        final TransactionStatus status1 = ti.registerTransaction();
+        final TransactionStatus status2 = ti.registerTransaction();
+
+        /*
+         * Two uncommitted versions from different transactions make prune's
+         * first pass throw "Multiple uncommitted versions" after it has marked
+         * the first version. The non-zero offset emulates in-page pruning.
+         */
+        final int offset = 117;
+        final byte[] bytes = new byte[offset + 100];
+        final byte[] v1 = { 0xA, 0xB, 0xC };
+        final byte[] v2 = { 0xD, 0xE };
+        int length = MVV.storeVersion(bytes, offset, -1, bytes.length, TransactionIndex.ts2vh(status1.getTs()), v1, 0,
+                v1.length) & STORE_LENGTH_MASK;
+        length = MVV.storeVersion(bytes, offset, length, bytes.length, TransactionIndex.ts2vh(status2.getTs()), v2, 0,
+                v2.length) & STORE_LENGTH_MASK;
+
+        final byte[] before = bytes.clone();
+        try {
+            MVV.prune(bytes, offset, length, ti, true, new ArrayList<MVV.PrunedVersion>());
+            fail("expected CorruptValueException");
+        } catch (final CorruptValueException expected) {
+        }
+        assertArrayEquals("prune must leave the byte array unchanged when it throws", before, bytes);
+    }
+
+    /**
+     * Issue #286: on a misaligned (corrupt) MVV the tightened first-pass guard
+     * throws before the traversal can mark outside the MVV region, so the
+     * finally-block safety net must stop at the same point. A net that keeps
+     * iterating while inside the region would unmark() — write — past the
+     * region end, into the next record of a live buffer page.
+     */
+    @Test
+    public void pruneExceptionMustNotUnmarkPastRegionEnd() throws Exception {
+        final TimestampAllocator tsa = new TimestampAllocator();
+        final TransactionIndex ti = new TransactionIndex(tsa, 1);
+        final TransactionStatus status = ti.registerTransaction();
+
+        /*
+         * One uncommitted version, so the first pass marks it, followed by a
+         * claimed region length that leaves the next version header straddling
+         * the region end: the guard throws with the mark still set. The 0xFF
+         * fill makes any out-of-region unmark() visible (bit 15 cleared).
+         */
+        final int offset = 117;
+        final byte[] bytes = new byte[offset + 100];
+        Arrays.fill(bytes, (byte) 0xFF);
+        final byte[] v1 = { 0xA, 0xB, 0xC };
+        final int stored = MVV.storeVersion(bytes, offset, -1, bytes.length, TransactionIndex.ts2vh(status.getTs()),
+                v1, 0, v1.length) & STORE_LENGTH_MASK;
+        final int length = stored + 5;
+
+        final byte[] before = bytes.clone();
+        try {
+            MVV.prune(bytes, offset, length, ti, true, new ArrayList<MVV.PrunedVersion>());
+            fail("expected CorruptValueException");
+        } catch (final CorruptValueException expected) {
+        }
+        assertArrayEquals("prune must not write outside the MVV region when it throws", before, bytes);
     }
 
     //

--- a/persistit/core/src/test/java/com/persistit/TransactionTest2.java
+++ b/persistit/core/src/test/java/com/persistit/TransactionTest2.java
@@ -25,6 +25,7 @@ import com.persistit.exception.PersistitIOException;
 import com.persistit.exception.PersistitInterruptedException;
 import com.persistit.exception.RollbackException;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InterruptedIOException;
@@ -34,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -62,8 +64,21 @@ public class TransactionTest2 extends PersistitUnitTestCase {
     static AtomicInteger _completedTransactionCount = new AtomicInteger();
     static AtomicInteger _failedTransactionCount = new AtomicInteger();
     static AtomicInteger _strandedThreads = new AtomicInteger();
+    static AtomicReference<Throwable> _firstFailure = new AtomicReference<Throwable>();
 
     static int _threadCounter = 0;
+
+    /*
+     * The counters are static and shared by every test in this class; reset
+     * them so each test's assertions see only its own failures.
+     */
+    @Before
+    public void resetCounters() {
+        _retriedTransactionCount.set(0);
+        _completedTransactionCount.set(0);
+        _failedTransactionCount.set(0);
+        _firstFailure.set(null);
+    }
 
     int _threadIndex = 0;
 
@@ -228,6 +243,8 @@ public class TransactionTest2 extends PersistitUnitTestCase {
         assertEquals("Starting and ending balance don't agree", startingBalance, endingBalance);
         assertTrue("ATC has very old transaction",
                 ti.getActiveTransactionCeiling() - ti.getActiveTransactionFloor() < 10000);
+        assertEquals("Worker threads died with unexpected exceptions; first was " + _firstFailure.get(), 0,
+                _failedTransactionCount.get());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -314,6 +331,7 @@ public class TransactionTest2 extends PersistitUnitTestCase {
                 // expected
             } else {
                 exception.printStackTrace();
+                _firstFailure.compareAndSet(null, exception);
                 _failedTransactionCount.incrementAndGet();
             }
         } catch (final Throwable throwable) {
@@ -321,6 +339,7 @@ public class TransactionTest2 extends PersistitUnitTestCase {
             // AssertionError must be reported and counted rather than
             // silently killing the worker thread (see issue #265).
             throwable.printStackTrace();
+            _firstFailure.compareAndSet(null, throwable);
             _failedTransactionCount.incrementAndGet();
         }
     }


### PR DESCRIPTION
## Summary

Fixes the residual interrupt-corruption failure from #286: `TransactionTest2.transactionsWithInterrupts` intermittently crashed with `ArrayIndexOutOfBoundsException: Index -32745 out of bounds` in `MVV.visitAllVersions` during an MVCC fetch (Windows / JDK 11, interrupt stress).

## Root cause

Two cooperating defects in `MVV`:

1. **Write side (the actual corruption).** `MVV.prune`'s `finally`-block safety net, which is supposed to remove transient mark bits when prune exits via an exception, used the wrong loop bound: `while (index < length)` instead of `while (index < offset + length)`. For in-page pruning (`Buffer.pruneMvvValuesHelper` passes a large in-page `offset`), the loop body never ran, so an interrupted prune (`PersistitInterruptedException` out of `TransactionIndex.commitStatus`, a `TimeoutException`, or a `CorruptValueException`) left `0x8000` mark bits set in the version length fields of the live buffer page. The exclusive claim held during pruning means this leftover state — not any transient race — is the only way readers can ever observe marks. The observed stack (the crash surfaced in the *main* thread's final balance scan, after all workers had died) confirms the marks persisted in the page.

2. **Read side (the crash).** The fetch paths — `visitAllVersions`, `fetchVersion`, `fetchVersionByOffset` — read the per-version length with signed `Util.getShort` and without stripping the mark bit, unlike the canonical `getLength()` accessor (`Util.getChar & MAX_LENGTH_MASK`). A marked version therefore produced a negative length (`L | 0x8000` sign-extended), drove the scan offset negative, and the next `Util.getLong` threw a raw AIOOBE. The observed index `-32745` matches this arithmetic exactly (`offset_ver + 10 + L - 32768` with `offset_ver + L = 13`).

## Changes

- `MVV.prune`: make the `finally`-block unmark loop mirror the first pass exactly (same advance, same guard, with the array-end bound covering the unguarded first iteration) and tighten the first pass's corruption guard so a misaligned traversal throws `CorruptValueException` before it can read or mark outside the MVV region; drop the early `break` on zero-length versions (a zero-length version is a legal undefined value, and the loop always advances by at least `LENGTH_PER_VERSION`).
- `MVV.visitAllVersions` / `fetchVersion` / `fetchVersionByOffset`: read version lengths unsigned with the mark bit stripped, matching `getLength()`. Leftover marks (including any already persisted to disk) become harmless — the true length is read.
- Add bounds checks to the scan loops and the by-offset copy: a version header or value extending past the MVV bounds now throws a clean `CorruptValueException` instead of escaping as an AIOOBE.
- `MVV.storeVersion`: fix a latent bug found while writing the regression test — the existing-MVV detection read `target[0]` instead of `target[targetOffset]`, so at a non-zero offset an existing MVV was treated as a primordial value and nested. (Unreachable in production today: `Exchange` merges MVVs in spare buffers at offset 0 and writes pages via `RawValueWriter`.)

## Tests

- `MVVTest`: six new deterministic regression tests — marked-version reads through all three fetch paths, corrupt-length inputs now throwing `CorruptValueException`, and two prune safety-net tests: `pruneExceptionUnmarksVersionsAtNonZeroOffset` reproduces the interrupted-prune scenario (two uncommitted versions at a non-zero offset → prune throws after marking) and asserts the byte array is left unchanged, while `pruneExceptionMustNotUnmarkPastRegionEnd` covers the misaligned-MVV case where the net must stop at the same point as the first pass's corruption guard instead of writing past the region end. All six fail on the previous code; `visitMarkedVersion` reproduces the CI signature (`ArrayIndexOutOfBoundsException: Index -32747`).
- `TransactionTest2.transactionsWithInterrupts`: reset the shared static counters at the start and assert `_failedTransactionCount == 0` at the end, so a worker dying with an unexpected exception fails the test loudly instead of only printing a stack trace.

Local runs: `MVVTest` 39/39, `MVCCBasicTest` + `MVCCPruneTest` + `MVCCPruneBufferTest` + `MVCCConcurrentTest` + `TransactionIndexTest` 97 green (1 pre-existing skip), `TransactionTest2` 5/5.

Fixes #286

