### PR TITLE
[#287] Fix race between close() and scheduled signature task dropping the final CSV signature

### DIFF
--- a/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/SecureCsvWriter.java
+++ b/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/SecureCsvWriter.java
@@ -167,9 +167,7 @@ class SecureCsvWriter implements CsvWriter, RolloverLifecycleHook {
                 @Override
                 public void run() {
                     try {
-                    	logger.trace("THREAD !!!");
-                    	if(!signatureLock.isLocked())
-                    		writeSignature(csvWriter);
+                        writeSignature(csvWriter);
                     } catch (Exception ex) {
                         logger.error("An error occurred while writing the signature", ex);
                     }
@@ -252,8 +250,7 @@ class SecureCsvWriter implements CsvWriter, RolloverLifecycleHook {
     private void forceWriteSignature(Writer writer) throws IOException {
         if (scheduledSignature != null && scheduledSignature.cancel(false)) {
             // We were able to cancel it before it starts, so let's generate the signature now.
-        	writeSignature(writer);
-            
+            writeSignature(writer);
         }
     }
 
@@ -272,7 +269,7 @@ class SecureCsvWriter implements CsvWriter, RolloverLifecycleHook {
     void writeSignature(Writer writer) throws IOException {
         // We have to prevent from writing another line between the signature calculation
         // and the signature's row write, as the calculation uses the lastHMAC.
-    	signatureLock.lock();
+        signatureLock.lock();
         try {
             lastSignature = secureStorage.sign(dataToSign(lastSignature, lastHMAC));
             logger.trace("Calculated new Signature");
@@ -344,7 +341,6 @@ class SecureCsvWriter implements CsvWriter, RolloverLifecycleHook {
                     && (scheduledSignature == null || scheduledSignature.isDone())) {
                 logger.trace("Triggering a new signature task to be executed in {}", signatureInterval);
                 try {
-                	logger.trace("SHCHEDULED!!");
                     scheduledSignature = scheduler.schedule(signatureTask, signatureInterval.getValue(),
                             signatureInterval.getUnit());
                 } catch (RejectedExecutionException e) {

--- a/commons/audit/handler-csv/src/test/java/org/forgerock/audit/handlers/csv/SecureCsvWriterTest.java
+++ b/commons/audit/handler-csv/src/test/java/org/forgerock/audit/handlers/csv/SecureCsvWriterTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.audit.handlers.csv;
 
@@ -149,9 +150,11 @@ public class SecureCsvWriterTest {
         final File actual = new File("target/test-classes/shouldGenerateHMACColumn-actual.txt");
         actual.delete();
         final String header = "FOO";
+        // Use a signature interval long enough to never fire during the test, so that the final
+        // signature is deterministically written by close() and the file content is predictable.
         try (SecureCsvWriter secureCsvWriter = new SecureCsvWriter(
-                actual, new String[]{header}, CsvPreference.EXCEL_PREFERENCE, createBasicSecureConfig(),
-                keyStoreHandler, random)) {
+                actual, new String[]{header}, CsvPreference.EXCEL_PREFERENCE,
+                createBasicSecureConfig("5 minutes"), keyStoreHandler, random)) {
             Map<String, String> values;
 
 //            secureCsvWriter.writeHeader(header);
@@ -182,8 +185,8 @@ public class SecureCsvWriterTest {
         actual.delete();
         final String header = "FOO";
         try (SecureCsvWriter secureCsvWriter = new SecureCsvWriter(
-                actual, new String[]{header}, CsvPreference.EXCEL_PREFERENCE, createBasicSecureConfig(),
-                keyStoreHandler, random)) {
+                actual, new String[]{header}, CsvPreference.EXCEL_PREFERENCE,
+                createBasicSecureConfig(signatureInterval.toString()), keyStoreHandler, random)) {
 
             secureCsvWriter.writeEvent(singletonMap(header, "bar"));
 
@@ -211,10 +214,10 @@ public class SecureCsvWriterTest {
                 new File("target/test-classes/shouldGeneratePeriodicallySignature-expected.txt")));
     }
 
-    private CsvAuditEventHandlerConfiguration createBasicSecureConfig() {
+    private CsvAuditEventHandlerConfiguration createBasicSecureConfig(String interval) {
         CsvAuditEventHandlerConfiguration configuration = new CsvAuditEventHandlerConfiguration();
         configuration.getSecurity().setEnabled(true);
-        configuration.getSecurity().setSignatureInterval(signatureInterval.toString());
+        configuration.getSecurity().setSignatureInterval(interval);
         return configuration;
     }
 


### PR DESCRIPTION
## Problem

`SecureCsvWriterTest.shouldGenerateHMACColumn` fails intermittently in CI: the final SIGNATURE row that `close()` is supposed to append is missing from the file. This is not test-only — the same race can drop the final (or a periodic) signature of a production audit CSV, making tamper-evident verification fail on an untampered file.

Two parties can write the final signature, and in an unlucky interleaving neither does:

- `close()` holds `signatureLock` and writes the signature only if `scheduledSignature.cancel(false)` returns `true`; once the timer has fired, it assumes the running task will write it.
- The task guards itself with `if (!signatureLock.isLocked())` — while `close()` (or any concurrent `writeEvent()`) holds the lock, the task silently exits without writing.

`ReentrantLock.isLocked()` is documented for monitoring only; using it as a synchronization decision is a classic check-then-act race. The guard is not upstream ForgeRock code — it was added in 2018 (489875550, "fix jdk 8.151 unit test") as a workaround, together with debug traces.

## Fix

- **`SecureCsvWriter`**: the scheduled task now calls `writeSignature()` unconditionally. It blocks on the reentrant `signatureLock`, and `close()` awaits scheduler termination before closing the writer, so exactly one final signature is always written: either `close()` cancels the task and writes it itself, or the already-started task writes it before the file is closed. The task's lock ordering (`signatureLock` → `RotatableWriter` read lock) is identical to a regular `writeEvent()`, and the rotation-check thread takes `signatureLock` first via `beforeRollingOver()`, so no new deadlock ordering is introduced. Leftover debug traces (`THREAD !!!`, `SHCHEDULED!!`) removed.
- **`SecureCsvWriterTest`**: `shouldGenerateHMACColumn` now uses a 5-minute signature interval so the timer can never fire mid-test and `close()` deterministically writes the single expected signature. This also removes a second latent flake mode (an extra signature row if the test thread stalls >100 ms between writes). `createBasicSecureConfig()` is parameterized by interval; `shouldGeneratePeriodicallySignature` keeps the 100 ms interval and still covers periodic signing on top of the fixed code.

## Testing

- Full `handler-csv` module suite: 27/27 pass.
- `SecureCsvWriterTest` run 15 consecutive times with zero failures.

Fixes #287
