### PR TITLE
[#290] Report leftover MVV mark bits in IntegrityCheck

### DIFF
--- a/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
+++ b/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
@@ -80,6 +80,7 @@ public class IntegrityCheck extends Task {
     private boolean _csv;
 
     private final ArrayList<Fault> _faults = new ArrayList<Fault>();
+    private int _faultCount;
     private int _markedVersionFaultCount;
     private final ArrayList<CleanupIndexHole> _holes = new ArrayList<CleanupIndexHole>();
 
@@ -201,10 +202,9 @@ public class IntegrityCheck extends Task {
             final int marked = MVV.countMarkedVersions(bytes, offset, length);
             if (marked > 0) {
                 _counters._markedVersionCount += marked;
-                if (addFault("MVV has " + plural(marked, "version") + " with a leftover mark bit", _currentPage, 0,
-                        foundAt)) {
-                    _markedVersionFaultCount++;
-                }
+                _markedVersionFaultCount++;
+                addFault("MVV has " + plural(marked, "version") + " with a leftover mark bit", _currentPage, 0,
+                        foundAt);
             }
             if (_versionVisitor._count > 0) {
                 _counters._mvvCount++;
@@ -314,9 +314,13 @@ public class IntegrityCheck extends Task {
                  * affected by a pre-#286 interrupted prune but do not block
                  * clearing the TransactionIndex: the prune pass above has
                  * already rewritten those marks (issue #292). Only other
-                 * faults and incomplete pruning count as failures here.
+                 * faults and incomplete pruning count as failures here. The
+                 * comparison uses fault counts, not the _faults list: the
+                 * list is capped at MAX_FAULTS, so a genuine fault found
+                 * after marked-version faults fill the cap would be missing
+                 * from the list but must still block the clear.
                  */
-                if (_faults.size() == _markedVersionFaultCount && _counters._mvvPageCount == _counters._prunedPageCount
+                if (_faultCount == _markedVersionFaultCount && _counters._mvvPageCount == _counters._prunedPageCount
                         && _counters._pruningErrorCount == 0) {
                     final int count = _persistit.getTransactionIndex().resetMVVCounts(startTimestamp);
                     postMessage(String.format("%,d aborted transactions were cleared by pruning", count), LOG_NORMAL);
@@ -356,17 +360,17 @@ public class IntegrityCheck extends Task {
         }
     }
 
-    private boolean addFault(final String description, final long page, final int level, final int position) {
+    private void addFault(final String description, final long page, final int level, final int position) {
         final Fault fault = new Fault(resourceName(), this, description, page, _treeDepth, level, position);
-        final boolean recorded = _faults.size() < MAX_FAULTS;
-        if (recorded)
+        _faultCount++;
+        if (_faults.size() < MAX_FAULTS)
             _faults.add(fault);
         postMessage(fault.toString(), LOG_VERBOSE);
-        return recorded;
     }
 
     private void addGarbageFault(final String description, final long page, final int level, final int position) {
         final Fault fault = new Fault(resourceName(), this, description, page, 3, level, position);
+        _faultCount++;
         if (_faults.size() < MAX_FAULTS)
             _faults.add(fault);
         postMessage(fault.toString(), LOG_VERBOSE);

--- a/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
+++ b/persistit/core/src/main/java/com/persistit/IntegrityCheck.java
@@ -60,6 +60,7 @@ public class IntegrityCheck extends Task {
 
     private Volume _currentVolume;
     private Tree _currentTree;
+    private long _currentPage;
     private LongBitSet _usedPageBits = new LongBitSet();
     private long _totalPages = 0;
     private long _pagesVisited = 0;
@@ -79,6 +80,7 @@ public class IntegrityCheck extends Task {
     private boolean _csv;
 
     private final ArrayList<Fault> _faults = new ArrayList<Fault>();
+    private int _markedVersionFaultCount;
     private final ArrayList<CleanupIndexHole> _holes = new ArrayList<CleanupIndexHole>();
 
     // Used in checking long values
@@ -98,6 +100,7 @@ public class IntegrityCheck extends Task {
         private long _mvvCount = 0;
         private long _mvvOverhead = 0;
         private long _mvvAntiValues = 0;
+        private long _markedVersionCount = 0;
         private long _pruningErrorCount = 0;
         private long _prunedPageCount = 0;
         private long _garbagePageCount = 0;
@@ -118,6 +121,7 @@ public class IntegrityCheck extends Task {
             _mvvCount = counters._mvvCount;
             _mvvOverhead = counters._mvvOverhead;
             _mvvAntiValues = counters._mvvAntiValues;
+            _markedVersionCount = counters._markedVersionCount;
             _pruningErrorCount = counters._pruningErrorCount;
             _prunedPageCount = counters._prunedPageCount;
             _garbagePageCount = counters._garbagePageCount;
@@ -135,6 +139,7 @@ public class IntegrityCheck extends Task {
             _mvvCount = counters._mvvCount - _mvvCount;
             _mvvOverhead = counters._mvvOverhead - _mvvOverhead;
             _mvvAntiValues = counters._mvvAntiValues - _mvvAntiValues;
+            _markedVersionCount = counters._markedVersionCount - _markedVersionCount;
             _pruningErrorCount = counters._pruningErrorCount - _pruningErrorCount;
             _prunedPageCount = counters._prunedPageCount - _prunedPageCount;
             _garbagePageCount = counters._garbagePageCount - _garbagePageCount;
@@ -144,20 +149,21 @@ public class IntegrityCheck extends Task {
         public String toString() {
             return String.format("Index pages/bytes: %,d / %,d Data pages/bytes: %,d / %,d"
                     + " LongRec pages/bytes: %,d / %,d  MVV pages/records/bytes/antivalues: "
-                    + "%,d / %,d / %,d / %,d  Holes %,d Pages pruned %,d", _indexPageCount, _indexBytesInUse,
-                    _dataPageCount, _dataBytesInUse, _longRecordPageCount, _longRecordBytesInUse, _mvvPageCount,
-                    _mvvCount, _mvvOverhead, _mvvAntiValues, _indexHoleCount, _prunedPageCount);
+                    + "%,d / %,d / %,d / %,d  Holes %,d Pages pruned %,d Marked versions %,d", _indexPageCount,
+                    _indexBytesInUse, _dataPageCount, _dataBytesInUse, _longRecordPageCount, _longRecordBytesInUse,
+                    _mvvPageCount, _mvvCount, _mvvOverhead, _mvvAntiValues, _indexHoleCount, _prunedPageCount,
+                    _markedVersionCount);
         }
 
         private String toCSV() {
-            return String.format("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d", _indexPageCount, _indexBytesInUse,
+            return String.format("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d", _indexPageCount, _indexBytesInUse,
                     _dataPageCount, _dataBytesInUse, _longRecordPageCount, _longRecordBytesInUse, _mvvPageCount,
-                    _mvvCount, _mvvOverhead, _mvvAntiValues, _indexHoleCount, _prunedPageCount);
+                    _mvvCount, _mvvOverhead, _mvvAntiValues, _indexHoleCount, _prunedPageCount, _markedVersionCount);
         }
 
         private final static String CSV_HEADERS = "IndexPages,IndexBytes,"
                 + "DataPages,DataBytes,LongRecordPages,LongRecordBytes,MvvPages,"
-                + "MvvRecords,MvvOverhead,MvvAntiValues,IndexHoles,PrunedPages";
+                + "MvvRecords,MvvOverhead,MvvAntiValues,IndexHoles,PrunedPages,MarkedVersions";
 
     }
 
@@ -186,6 +192,20 @@ public class IntegrityCheck extends Task {
         protected void visitDataRecord(final Key key, final int foundAt, final int tail, final int klength,
                 final int offset, final int length, final byte[] bytes) throws PersistitException {
             MVV.visitAllVersions(_versionVisitor, bytes, offset, length);
+            /*
+             * Scanned only after visitAllVersions has validated the version
+             * structure. Leftover prune marks read normally (the length
+             * accessors strip the mark bit), so only this dedicated scan can
+             * detect and report them - see issue #290.
+             */
+            final int marked = MVV.countMarkedVersions(bytes, offset, length);
+            if (marked > 0) {
+                _counters._markedVersionCount += marked;
+                if (addFault("MVV has " + plural(marked, "version") + " with a leftover mark bit", _currentPage, 0,
+                        foundAt)) {
+                    _markedVersionFaultCount++;
+                }
+            }
             if (_versionVisitor._count > 0) {
                 _counters._mvvCount++;
                 final int voffset = _versionVisitor._lastOffset;
@@ -289,7 +309,14 @@ public class IntegrityCheck extends Task {
                 postMessage("Total " + toString(), LOG_NORMAL);
             }
             if (_pruneAndClear) {
-                if (_faults.isEmpty() && _counters._mvvPageCount == _counters._prunedPageCount
+                /*
+                 * Leftover mark-bit faults (issue #290) identify volumes
+                 * affected by a pre-#286 interrupted prune but do not block
+                 * clearing the TransactionIndex: the prune pass above has
+                 * already rewritten those marks (issue #292). Only other
+                 * faults and incomplete pruning count as failures here.
+                 */
+                if (_faults.size() == _markedVersionFaultCount && _counters._mvvPageCount == _counters._prunedPageCount
                         && _counters._pruningErrorCount == 0) {
                     final int count = _persistit.getTransactionIndex().resetMVVCounts(startTimestamp);
                     postMessage(String.format("%,d aborted transactions were cleared by pruning", count), LOG_NORMAL);
@@ -329,11 +356,13 @@ public class IntegrityCheck extends Task {
         }
     }
 
-    private void addFault(final String description, final long page, final int level, final int position) {
+    private boolean addFault(final String description, final long page, final int level, final int position) {
         final Fault fault = new Fault(resourceName(), this, description, page, _treeDepth, level, position);
-        if (_faults.size() < MAX_FAULTS)
+        final boolean recorded = _faults.size() < MAX_FAULTS;
+        if (recorded)
             _faults.add(fault);
         postMessage(fault.toString(), LOG_VERBOSE);
+        return recorded;
     }
 
     private void addGarbageFault(final String description, final long page, final int level, final int position) {
@@ -542,6 +571,16 @@ public class IntegrityCheck extends Task {
      */
     public long getMvvAntiValues() {
         return _counters._mvvAntiValues;
+    }
+
+    /**
+     * @return Count of MVV versions whose length field still carries a
+     *         leftover prune mark bit, left behind by a prune interrupted
+     *         before the issue #286 fix. Such versions read normally but
+     *         indicate the volume was corrupted; pruning rewrites them.
+     */
+    public long getMarkedVersionCount() {
+        return _counters._markedVersionCount;
     }
 
     /**
@@ -1144,6 +1183,7 @@ public class IntegrityCheck extends Task {
     }
 
     private boolean verifyPage(final Buffer buffer, final long page, final int level, final Key key, final Tree tree) {
+        _currentPage = page;
         if (buffer.getPageAddress() != page) {
             addFault("Buffer contains wrong page " + buffer.getPageAddress(), page, level, 0);
             return false;

--- a/persistit/core/src/main/java/com/persistit/MVV.java
+++ b/persistit/core/src/main/java/com/persistit/MVV.java
@@ -654,6 +654,37 @@ class MVV {
         return true;
     }
 
+    /**
+     * Count versions whose length field still carries the mark bit. Marks are
+     * transient state private to {@link #prune} and must never be observable
+     * outside it; a non-zero count on a stored MVV means the value was
+     * corrupted by a prune interrupted before the issue #286 fix. The length
+     * accessors strip the mark bit silently, so such versions read normally
+     * and only this scan can detect them (issue #290).
+     *
+     * @param bytes
+     *            the byte array
+     * @param offset
+     *            the index of the first byte of the MVV within the byte array
+     * @param length
+     *            the count of bytes in the MVV
+     * @return the number of marked versions, 0 for a non-MVV value
+     */
+    static int countMarkedVersions(final byte[] bytes, final int offset, final int length) {
+        if (!isArrayMVV(bytes, offset, length)) {
+            return 0;
+        }
+        int marked = 0;
+        int from = offset + 1;
+        while (from + LENGTH_PER_VERSION <= offset + length) {
+            if (isMarked(bytes, from)) {
+                marked++;
+            }
+            from += getLength(bytes, from) + LENGTH_PER_VERSION;
+        }
+        return marked;
+    }
+
     static boolean verify(final TransactionIndex ti, final byte[] bytes, final int offset, final int length) {
         if (!isArrayMVV(bytes, offset, length)) {
             /*

--- a/persistit/core/src/test/java/com/persistit/IntegrityCheckTest.java
+++ b/persistit/core/src/test/java/com/persistit/IntegrityCheckTest.java
@@ -23,8 +23,12 @@ import com.persistit.exception.PersistitException;
 import org.junit.Test;
 
 import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -97,6 +101,88 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
         final IntegrityCheck icheck = icheck();
         icheck.checkTree(ex.getTree());
         assertTrue(icheck.getFaults().length > 0);
+    }
+
+    /**
+     * Issue #290: a leftover prune mark bit (pre-#288 interrupted-prune
+     * corruption) reads normally through all fetch paths, so IntegrityCheck
+     * must detect it explicitly and report it as a fault.
+     */
+    @Test
+    public void testLeftoverMarkBitsReported() throws Exception {
+        final Exchange ex = _persistit.getExchange(_volumeName, "mvv", true);
+        disableBackgroundCleanup();
+        transactionalStore(ex);
+
+        IntegrityCheck icheck = icheck();
+        icheck.checkTree(ex.getTree());
+        assertEquals(0, icheck.getFaults().length);
+        assertEquals(0, icheck.getMarkedVersionCount());
+
+        final int[] corrupted = corrupt5(ex);
+        final int corruptedValues = corrupted[0];
+        final int markedVersions = corrupted[1];
+        assertTrue(corruptedValues > 0);
+        assertTrue("some values must carry more than one mark", markedVersions > corruptedValues);
+
+        icheck = icheck();
+        icheck.checkTree(ex.getTree());
+        assertEquals(corruptedValues, icheck.getFaults().length);
+        assertEquals(markedVersions, icheck.getMarkedVersionCount());
+    }
+
+    /**
+     * Issue #290: pruning rewrites marked versions, so icheck with pruning
+     * enabled is the remediation path - a subsequent icheck must be clean.
+     */
+    @Test
+    public void testPruneClearsLeftoverMarkBits() throws Exception {
+        final Exchange ex = _persistit.getExchange(_volumeName, "mvv", true);
+        disableBackgroundCleanup();
+        transactionalStore(ex);
+        _persistit.getTransactionIndex().updateActiveTransactionCache();
+
+        final SortedMap<String, String> expectedContents = treeContents(ex);
+        assertTrue(corrupt5(ex)[0] > 0);
+
+        IntegrityCheck icheck = icheck();
+        icheck.setPruneEnabled(true);
+        icheck.checkTree(ex.getTree());
+        assertTrue(icheck.getMarkedVersionCount() > 0);
+        assertTrue(icheck.getPrunedPagesCount() > 0);
+
+        assertEquals("remediation must not change the visible contents", expectedContents, treeContents(ex));
+
+        icheck = icheck();
+        icheck.checkTree(ex.getTree());
+        assertEquals(0, icheck.getMarkedVersionCount());
+        assertEquals(0, icheck.getFaults().length);
+    }
+
+    /**
+     * Issues #290/#292: icheck -P reports leftover mark bits as faults but
+     * must still clear the TransactionIndex - the prune pass has already
+     * rewritten the marks, so they are not a pruning failure.
+     */
+    @Test
+    public void testPruneAndClearWithLeftoverMarkBits() throws Exception {
+        final Exchange ex = _persistit.getExchange(_volumeName, "mvv", true);
+        disableBackgroundCleanup();
+        transactionalStore(ex);
+        _persistit.getTransactionIndex().updateActiveTransactionCache();
+
+        assertTrue(corrupt5(ex)[0] > 0);
+
+        final IntegrityCheck icheck = (IntegrityCheck) CLI.parseTask(_persistit, "icheck trees=* -u -P");
+        final StringWriter output = new StringWriter();
+        icheck.setMessageWriter(new PrintWriter(output));
+        icheck.setup(1, "icheck", "cli", 0, 5);
+        icheck.run();
+
+        assertTrue(icheck.getMarkedVersionCount() > 0);
+        assertTrue(icheck.hasFaults());
+        assertTrue(output.toString(), output.toString().contains("aborted transactions were cleared by pruning"));
+        assertFalse(output.toString(), output.toString().contains("PruneAndClear failed"));
     }
 
     @Test
@@ -283,26 +369,52 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
         buffer.release();
     }
 
+    private interface MVVCorruption {
+        /** Corrupts one stored MVV value; returns its contribution to the total */
+        int corrupt(byte[] bytes, int length);
+    }
+
+    /**
+     * Applies a corruption to the raw bytes of up to ten stored MVV values
+     *
+     * @param ex
+     * @param corruption
+     * @return the number of values corrupted and the summed corruption
+     *         contributions, as a two-element array
+     * @throws PersistitException
+     */
+    private int[] corruptMVVs(final Exchange ex, final MVVCorruption corruption) throws PersistitException {
+        ex.ignoreMVCCFetch(true);
+        try {
+            ex.clear().to(key(500));
+            int corrupted = 0;
+            int total = 0;
+            while (corrupted < 10 && ex.next()) {
+                final byte[] bytes = ex.getValue().getEncodedBytes();
+                final int length = ex.getValue().getEncodedSize();
+                if (MVV.isArrayMVV(bytes, 0, length)) {
+                    total += corruption.corrupt(bytes, length);
+                    ex.store();
+                    corrupted++;
+                }
+            }
+            return new int[] { corrupted, total };
+        } finally {
+            ex.ignoreMVCCFetch(false);
+        }
+    }
+
     /**
      * Corrupts some MVV values on a page by damaging a version length field
-     * 
+     *
      * @param ex
      * @throws PersistitException
      */
     private void corrupt2(final Exchange ex) throws PersistitException {
-        ex.ignoreMVCCFetch(true);
-        ex.clear().to(key(500));
-        int corrupted = 0;
-        while (corrupted < 10 && ex.next()) {
-            final byte[] bytes = ex.getValue().getEncodedBytes();
-            final int length = ex.getValue().getEncodedSize();
-            if (MVV.isArrayMVV(bytes, 0, length)) {
-                bytes[9]++;
-                ex.store();
-                corrupted++;
-            }
-        }
-        ex.ignoreMVCCFetch(false);
+        corruptMVVs(ex, (bytes, length) -> {
+            bytes[9]++;
+            return 1;
+        });
     }
 
     /**
@@ -336,6 +448,45 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
         final Buffer buffer = ex.getBufferPool().get(ex.getVolume(), copy.getPageAddress(), true, true);
         ex.getVolume().getStructure().deallocateGarbageChain(buffer.getPageAddress(), buffer.getRightSibling());
         buffer.release();
+    }
+
+    /**
+     * Simulates the pre-#288 interrupted-prune corruption (issue #286) by
+     * setting the leftover mark bit on every version of some MVV values
+     *
+     * @param ex
+     * @return the number of values corrupted and the total number of versions
+     *         marked, as a two-element array
+     * @throws PersistitException
+     */
+    private int[] corrupt5(final Exchange ex) throws PersistitException {
+        return corruptMVVs(ex, (bytes, length) -> {
+            int marked = 0;
+            int from = 1;
+            while (from + MVV.LENGTH_PER_VERSION <= length) {
+                MVV.mark(bytes, from);
+                marked++;
+                from += MVV.getLength(bytes, from) + MVV.LENGTH_PER_VERSION;
+            }
+            return marked;
+        });
+    }
+
+    /**
+     * Returns the visible key/value contents of the tree as seen by a
+     * non-transactional traversal
+     *
+     * @param ex
+     * @return the visible contents, keyed by decoded key string
+     * @throws PersistitException
+     */
+    private SortedMap<String, String> treeContents(final Exchange ex) throws PersistitException {
+        final SortedMap<String, String> contents = new TreeMap<String, String>();
+        ex.clear().append(Key.BEFORE);
+        while (ex.next()) {
+            contents.put(ex.getKey().decodeString(), ex.getValue().getString());
+        }
+        return contents;
     }
 
     private IntegrityCheck icheck() {

--- a/persistit/core/src/test/java/com/persistit/IntegrityCheckTest.java
+++ b/persistit/core/src/test/java/com/persistit/IntegrityCheckTest.java
@@ -101,6 +101,12 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
         final IntegrityCheck icheck = icheck();
         icheck.checkTree(ex.getTree());
         assertTrue(icheck.getFaults().length > 0);
+        /*
+         * A structurally corrupt MVV must not inflate the marked-version
+         * counter: the leftover-mark scan runs only after visitAllVersions
+         * has validated the record.
+         */
+        assertEquals(0, icheck.getMarkedVersionCount());
     }
 
     /**
@@ -183,6 +189,34 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
         assertTrue(icheck.hasFaults());
         assertTrue(output.toString(), output.toString().contains("aborted transactions were cleared by pruning"));
         assertFalse(output.toString(), output.toString().contains("PruneAndClear failed"));
+    }
+
+    /**
+     * The -P gate must compare fault counts, not the MAX_FAULTS-capped fault
+     * list: with more than MAX_FAULTS marked-version faults the list holds
+     * only them, and a genuine fault found later (here a corrupt garbage
+     * chain, checked after the trees) is not recorded in the list - it must
+     * still block clearing the TransactionIndex.
+     */
+    @Test
+    public void testPruneAndClearBlockedByFaultBeyondFaultCap() throws Exception {
+        final Exchange ex = _persistit.getExchange(_volumeName, "mvv", true);
+        disableBackgroundCleanup();
+        transactionalStore(ex);
+        _persistit.getTransactionIndex().updateActiveTransactionCache();
+
+        assertTrue(corrupt5(ex, 0, IntegrityCheck.MAX_FAULTS + 1)[0] > IntegrityCheck.MAX_FAULTS);
+        corrupt4(ex);
+
+        final IntegrityCheck icheck = (IntegrityCheck) CLI.parseTask(_persistit, "icheck trees=* -u -P");
+        final StringWriter output = new StringWriter();
+        icheck.setMessageWriter(new PrintWriter(output));
+        icheck.setup(1, "icheck", "cli", 0, 5);
+        icheck.run();
+
+        assertTrue(icheck.getMarkedVersionCount() > 0);
+        assertTrue(output.toString(), output.toString().contains("PruneAndClear failed"));
+        assertFalse(output.toString(), output.toString().contains("aborted transactions were cleared by pruning"));
     }
 
     @Test
@@ -376,6 +410,7 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
 
     /**
      * Applies a corruption to the raw bytes of up to ten stored MVV values
+     * following key 500
      *
      * @param ex
      * @param corruption
@@ -384,12 +419,29 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
      * @throws PersistitException
      */
     private int[] corruptMVVs(final Exchange ex, final MVVCorruption corruption) throws PersistitException {
+        return corruptMVVs(ex, 500, 10, corruption);
+    }
+
+    /**
+     * Applies a corruption to the raw bytes of up to <code>limit</code>
+     * stored MVV values following <code>startKey</code>
+     *
+     * @param ex
+     * @param startKey
+     * @param limit
+     * @param corruption
+     * @return the number of values corrupted and the summed corruption
+     *         contributions, as a two-element array
+     * @throws PersistitException
+     */
+    private int[] corruptMVVs(final Exchange ex, final int startKey, final int limit, final MVVCorruption corruption)
+            throws PersistitException {
         ex.ignoreMVCCFetch(true);
         try {
-            ex.clear().to(key(500));
+            ex.clear().to(key(startKey));
             int corrupted = 0;
             int total = 0;
-            while (corrupted < 10 && ex.next()) {
+            while (corrupted < limit && ex.next()) {
                 final byte[] bytes = ex.getValue().getEncodedBytes();
                 final int length = ex.getValue().getEncodedSize();
                 if (MVV.isArrayMVV(bytes, 0, length)) {
@@ -460,7 +512,15 @@ public class IntegrityCheckTest extends PersistitUnitTestCase {
      * @throws PersistitException
      */
     private int[] corrupt5(final Exchange ex) throws PersistitException {
-        return corruptMVVs(ex, (bytes, length) -> {
+        return corrupt5(ex, 500, 10);
+    }
+
+    /**
+     * Same as {@link #corrupt5(Exchange)} for up to <code>limit</code> values
+     * following <code>startKey</code>
+     */
+    private int[] corrupt5(final Exchange ex, final int startKey, final int limit) throws PersistitException {
+        return corruptMVVs(ex, startKey, limit, (bytes, length) -> {
             int marked = 0;
             int from = 1;
             while (from + MVV.LENGTH_PER_VERSION <= length) {

--- a/persistit/core/src/test/java/com/persistit/MVVTest.java
+++ b/persistit/core/src/test/java/com/persistit/MVVTest.java
@@ -625,6 +625,34 @@ public class MVVTest {
         assertArrayEquals("prune must not write outside the MVV region when it throws", before, bytes);
     }
 
+    /**
+     * Issue #290: leftover mark bits are invisible to the read paths (the
+     * length accessors strip them), so IntegrityCheck needs a dedicated scan
+     * to detect them.
+     */
+    @Test
+    public void countMarkedVersions() {
+        final byte[] source = newArray(TYPE_MVV, 0, 0, 0, 0, 0, 0, 0, 10, 0, 2, 0xA, 0xB, 0, 0, 0, 0, 0, 0, 0, 11, 0,
+                3, 0xC, 0xD, 0xE);
+        assertEquals(0, MVV.countMarkedVersions(source, 0, source.length));
+        MVV.mark(source, 1);
+        assertEquals(1, MVV.countMarkedVersions(source, 0, source.length));
+        MVV.mark(source, 13);
+        assertEquals(2, MVV.countMarkedVersions(source, 0, source.length));
+        MVV.unmark(source, 1);
+        assertEquals(1, MVV.countMarkedVersions(source, 0, source.length));
+        MVV.unmark(source, 13);
+        assertEquals(0, MVV.countMarkedVersions(source, 0, source.length));
+    }
+
+    @Test
+    public void countMarkedVersionsNonMVV() {
+        final byte[] source = newArray(0xA, 0xB, 0xC);
+        assertEquals(0, MVV.countMarkedVersions(source, 0, source.length));
+        assertEquals(0, MVV.countMarkedVersions(source, 0, 0));
+        assertEquals(0, MVV.countMarkedVersions(source, 0, -1));
+    }
+
     //
     // Issue #292: prune uses the mark bit as private transient state and
     // assumes no version is marked on entry. A stale mark left on disk by a

--- a/persistit/doc/Management.rst
+++ b/persistit/doc/Management.rst
@@ -133,9 +133,9 @@ programmatically or through JMX. (You may specify any valid, available port.) Th
 Where ``classpath`` includes the Persistit library. Assuming the name of the script is ``pcli`` you can then invoke commands from a shell as shown in this example::
 
   /home/akiban:~$ pcli icheck -v -c "trees=*:Acc*"
-  Volume,Tree,Faults,IndexPages,IndexBytes,DataPages,DataBytes,LongRecordPages,LongRecordBytes,MvvPages,MvvRecords,MvvOverhead,MvvAntiValues,IndexHoles,PrunedPages
-  "persistit","AccumulatorRecoveryTest",0,3,24296,1519,15560788,0,0,1506,52192,721521,2397,0,0
-  "*","*",0,3,24296,1519,15560788,0,0,1506,52192,721521,2397,0,0
+  Volume,Tree,Faults,IndexPages,IndexBytes,DataPages,DataBytes,LongRecordPages,LongRecordBytes,MvvPages,MvvRecords,MvvOverhead,MvvAntiValues,IndexHoles,PrunedPages,MarkedVersions
+  "persistit","AccumulatorRecoveryTest",0,3,24296,1519,15560788,0,0,1506,52192,721521,2397,0,0,0
+  "*","*",0,3,24296,1519,15560788,0,0,1506,52192,721521,2397,0,0,0
   /home/akiban:~$
 
 Alternatively, you can use ``curl`` as follows::


### PR DESCRIPTION
## Summary

Implements the proposal from #290 (split out of PR #288, suggested by @maximthomas in the #288 review): `IntegrityCheck` now detects and reports MVV versions whose length field still carries a leftover `0x8000` mark bit — the on-disk residue of a prune interrupted before the #286 fix. Since PR #288 the read paths strip the mark bit silently, so such versions read normally and `icheck` reported affected volumes as clean; the mark survived until some future prune rewrote that version.

> **Note:** #288 and #293 have merged and the branch is rebased onto master — this PR is now a clean two-commit diff: `Report leftover MVV mark bits in IntegrityCheck` plus the review follow-up `Compare fault counts in the icheck -P gate`. Pruning is already safe (#292) now that this PR documents `icheck -p` as the remediation.

## Changes

- `MVV.countMarkedVersions(bytes, offset, length)`: a dedicated scan counting versions with the mark bit set. A separate scan rather than an extension of `MVV.VersionVisitor`: the interface has six implementations, and `sawVersion` hands out the post-header value offset (with no header at all for primordial values), so a visitor cannot see the mark anyway.
- `IntegrityCheck`: `visitDataRecord` scans each record for marks **after** `visitAllVersions` has validated the version structure, so a structurally corrupt MVV cannot produce a bogus marked-version fault next to its genuine `CorruptValueException` fault. Marked versions feed a new `MarkedVersions` counter (plain report, CSV, and a `getMarkedVersionCount()` getter) and add a `Fault` ("MVV has N versions with a leftover mark bit") with the page address and record position, so `hasFaults()` flags affected volumes.
- `icheck -p` remains the remediation path: `verifyPage` runs `buffer.verify` before pruning, so marks are reported first and then rewritten by the prune (#292 makes prune clear stale marks up front).
- `icheck -P` (pruneAndClear): marked-version faults are reported but do not block `resetMVVCounts` — by the time the run completes, the prune pass has already rewritten the marks, so only other faults and incomplete pruning count as failures. Without this, `-P` could never succeed on an affected volume.
- The `-P` gate compares fault **counts**, not the `MAX_FAULTS`-capped `_faults` list: on a volume with more than `MAX_FAULTS` marked-version records the list holds only marked-version faults, and a genuine fault found afterwards (the garbage chain is checked after the trees) is dropped from the list — comparing list size against the marked-fault count would converge and clear the TransactionIndex despite real corruption. `addFault`/`addGarbageFault` now count every fault found, recorded or not.

> **Output format note:** the plain report and the `icheck -c` CSV gain a trailing `MarkedVersions` column — breaking for anything parsing icheck output. The CSV example in `doc/Management.rst` is updated accordingly.

## Tests

- `MVVTest`: `countMarkedVersions` (mark/unmark transitions over a two-version MVV) and `countMarkedVersionsNonMVV` (non-MVV, zero and negative lengths).
- `IntegrityCheckTest`:
  - `corrupt2`/`corrupt5` share a `corruptMVVs` helper taking the mutation as a callback (parameterized by start key and record limit), with `try/finally` around `ignoreMVCCFetch`. `corrupt5` marks **every** version of each corrupted MVV, so the marked-version count exceeds the fault count (one fault per record) and the plural fault message is exercised.
  - `testLeftoverMarkBitsReported` asserts a clean tree reports nothing and a corrupted tree reports exactly one fault per corrupted record plus the exact marked-version total.
  - `testBrokenMVVs` additionally asserts a structurally corrupt MVV does not inflate the `MarkedVersions` counter.
  - `testPruneClearsLeftoverMarkBits` snapshots the visible key/value contents before corruption and asserts remediation (`icheck` with pruning) leaves them unchanged, then that a subsequent `icheck` is clean.
  - `testPruneAndClearWithLeftoverMarkBits` runs the real task path (`CLI.parseTask("icheck trees=* -u -P")`) and asserts the faults are reported while the TransactionIndex is still cleared ("aborted transactions were cleared by pruning", not "PruneAndClear failed").
  - `testPruneAndClearBlockedByFaultBeyondFaultCap` corrupts more than `MAX_FAULTS` records with leftover marks plus the garbage chain and asserts `-P` still refuses to clear ("PruneAndClear failed") — with the gate comparing the capped list instead of counts, this test fails with a wrongly cleared TransactionIndex.

Local runs: `IntegrityCheckTest` 12/12, `MVVTest` 45/45, `MVCCBasicTest` + `MVCCPruneTest` + `MVCCPruneBufferTest` + `TransactionIndexTest` + `Bug1017957Test` all green (1 pre-existing skip).

Fixes #290
