### PR TITLE
Replace deprecated method/constructor calls (CodeQL java/deprecated-call)

### DIFF
--- a/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
+++ b/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
@@ -422,7 +422,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
 
         // Read the comments in ForgeRockTestCase to understand what's
         // going on here.
-        final Object[] testInstances = result.getMethod().getInstances();
+        final Object[] testInstances = new Object[] { result.getMethod().getInstance() };
         for (final Object testInstance : testInstances) {
             if (testInstance instanceof ForgeRockTestCase) {
                 final ForgeRockTestCase testCase = (ForgeRockTestCase) testInstance;
@@ -449,7 +449,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
     }
 
     private void checkForInterleavedBetweenClasses(final ITestResult tr) {
-        final Object[] testInstances = tr.getMethod().getInstances();
+        final Object[] testInstances = new Object[] { tr.getMethod().getInstance() };
         // This will almost always have a single element. If it doesn't,
         // just skip it.
         if (testInstances.length != 1) {

--- a/commons/audit/core/src/main/java/org/forgerock/audit/util/ResourceExceptionsUtil.java
+++ b/commons/audit/core/src/main/java/org/forgerock/audit/util/ResourceExceptionsUtil.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.audit.util;
@@ -48,7 +49,7 @@ public final class ResourceExceptionsUtil {
         } catch (final Throwable tmp) {
             resourceResultCode = ResourceException.INTERNAL_ERROR;
         }
-        return ResourceException.getException(resourceResultCode, t.getMessage(), t);
+        return ResourceException.newResourceException(resourceResultCode, t.getMessage(), t);
     }
 
     /**

--- a/commons/audit/servlet/src/main/java/org/forgerock/audit/AuditHttpApplication.java
+++ b/commons/audit/servlet/src/main/java/org/forgerock/audit/AuditHttpApplication.java
@@ -35,6 +35,7 @@ import org.forgerock.http.routing.RoutingMode;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.Resources;
 import org.forgerock.json.resource.ServiceUnavailableException;
+import org.forgerock.json.resource.Applications;
 import org.forgerock.json.resource.http.CrestHttp;
 import org.forgerock.util.Factory;
 import org.slf4j.Logger;
@@ -83,7 +84,7 @@ public final class AuditHttpApplication implements HttpApplication {
             throw new HttpApplicationException(e);
         }
         router.addRoute(requestUriMatcher(RoutingMode.STARTS_WITH, AUDIT_ROOT_PATH),
-                CrestHttp.newHttpHandler(Resources.newInternalConnectionFactory(auditService)));
+                CrestHttp.newHttpHandler(Applications.simpleCrestApplication(Resources.newInternalConnectionFactory(auditService), null, null)));
         return router;
     }
 

--- a/commons/auth-filters/authn-filter/jaspi-functional-tests/src/main/java/org/forgerock/caf/authn/test/JaspiHttpApplication.java
+++ b/commons/auth-filters/authn-filter/jaspi-functional-tests/src/main/java/org/forgerock/caf/authn/test/JaspiHttpApplication.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.caf.authn.test;
@@ -31,6 +32,7 @@ import org.forgerock.http.io.Buffer;
 import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
 import org.forgerock.http.routing.Router;
+import org.forgerock.json.resource.Applications;
 import org.forgerock.json.resource.http.CrestHttp;
 import org.forgerock.util.Factory;
 import org.forgerock.util.promise.NeverThrowsException;
@@ -48,7 +50,7 @@ public class JaspiHttpApplication implements HttpApplication {
         Router router = new Router();
         router.addRoute(requestUriMatcher(RoutingMode.EQUALS, "/protected/resource"),
                 new ConfigurableAuthenticationFilterHandler());
-        router.setDefaultRoute(CrestHttp.newHttpHandler(ConfigurationConnectionFactory.getConnectionFactory()));
+        router.setDefaultRoute(CrestHttp.newHttpHandler(Applications.simpleCrestApplication(ConfigurationConnectionFactory.getConnectionFactory(), null, null)));
         return router;
     }
 

--- a/commons/auth-filters/authn-filter/jaspi-functional-tests/src/main/java/org/forgerock/caf/authn/test/runtime/GuiceModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-functional-tests/src/main/java/org/forgerock/caf/authn/test/runtime/GuiceModule.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions copyright 2024 3A Systems LLC.
+ * Portions copyright 2024-2026 3A Systems LLC.
  */
 
 package org.forgerock.caf.authn.test.runtime;
@@ -21,7 +21,7 @@ import static org.forgerock.caf.authentication.framework.AuthenticationFilter.Au
 import static org.forgerock.caf.authentication.framework.AuthenticationFilter.AuthenticationModuleBuilder.configureModule;
 import static org.forgerock.json.resource.Requests.newReadRequest;
 import static org.forgerock.json.resource.Resources.newInternalConnection;
-import static org.forgerock.json.resource.Resources.newSingleton;
+import static org.forgerock.json.resource.Resources.newHandler;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -96,7 +96,7 @@ public class GuiceModule extends AbstractModule {
     public AsyncServerAuthModule getSessionAuthModule(ConfigurationResource configurationResource, Injector injector)
             throws ResourceException, ClassNotFoundException {
 
-        ResourceResponse configuration = newInternalConnection(newSingleton(configurationResource))
+        ResourceResponse configuration = newInternalConnection(newHandler(configurationResource))
                 .read(new RootContext(), newReadRequest(""));
         JsonValue sessionModuleConfig = configuration.getContent().get("serverAuthContext").get("sessionModule");
         if (!sessionModuleConfig.isNull()) {
@@ -124,7 +124,7 @@ public class GuiceModule extends AbstractModule {
 
         List<AsyncServerAuthModule> authModules = new ArrayList<>();
 
-        ResourceResponse configuration = newInternalConnection(newSingleton(configurationResource))
+        ResourceResponse configuration = newInternalConnection(newHandler(configurationResource))
                 .read(new RootContext(), newReadRequest(""));
         JsonValue authModulesConfig = configuration.getContent().get("serverAuthContext").get("authModules");
         for (JsonValue authModuleConfig : authModulesConfig) {

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -558,7 +558,7 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
                 .enc(EncryptionMethod.A128CBC_HS256)
                 .done()
                 .claims(claimsSet)
-                .sign(signingHandler, SIGNING_ALGORITHM)
+                .signedWith(signingHandler, SIGNING_ALGORITHM)
                 .build();
     }
 

--- a/commons/auth-filters/authz-filter/framework-functional-tests/src/main/java/org/forgerock/authz/basic/AuthzHttpApplication.java
+++ b/commons/auth-filters/authz-filter/framework-functional-tests/src/main/java/org/forgerock/authz/basic/AuthzHttpApplication.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.authz.basic;
@@ -26,6 +27,7 @@ import org.forgerock.http.HttpApplication;
 import org.forgerock.http.HttpApplicationException;
 import org.forgerock.http.io.Buffer;
 import org.forgerock.http.routing.Router;
+import org.forgerock.json.resource.Applications;
 import org.forgerock.json.resource.http.CrestHttp;
 import org.forgerock.util.Factory;
 
@@ -40,9 +42,9 @@ public class AuthzHttpApplication implements HttpApplication {
     public Handler start() throws HttpApplicationException {
         Router router = new Router();
         router.addRoute(requestUriMatcher(STARTS_WITH, "basic/crest"),
-                CrestHttp.newHttpHandler(BasicAuthorizationConnectionFactory.getConnectionFactory()));
+                CrestHttp.newHttpHandler(Applications.simpleCrestApplication(BasicAuthorizationConnectionFactory.getConnectionFactory(), null, null)));
         router.addRoute(requestUriMatcher(STARTS_WITH, "modules/oauth2/crest"),
-                CrestHttp.newHttpHandler(OAuth2AuthorizationConnectionFactory.getConnectionFactory()));
+                CrestHttp.newHttpHandler(Applications.simpleCrestApplication(OAuth2AuthorizationConnectionFactory.getConnectionFactory(), null, null)));
         return router;
     }
 

--- a/commons/auth-filters/authz-filter/framework/src/main/java/org/forgerock/authz/filter/crest/AuthorizationFilters.java
+++ b/commons/auth-filters/authz-filter/framework/src/main/java/org/forgerock/authz/filter/crest/AuthorizationFilters.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.authz.filter.crest;
@@ -100,7 +101,7 @@ public final class AuthorizationFilters {
             filters.add(new AuthorizationFilter(module));
         }
 
-        return new FilterChain(Resources.newCollection(target), filters);
+        return new FilterChain(Resources.newHandler(target), filters);
     }
 
     /**
@@ -141,7 +142,7 @@ public final class AuthorizationFilters {
             filters.add(new AuthorizationFilter(module));
         }
 
-        return new FilterChain(Resources.newSingleton(target), filters);
+        return new FilterChain(Resources.newHandler(target), filters);
     }
 
     /**
@@ -209,7 +210,7 @@ public final class AuthorizationFilters {
          * @return A {@code ResourceException} representing a {@code Unauthorized} request.
          */
         private ResourceException newUnauthorizedException(AuthorizationResult result) {
-            final ResourceException e = ResourceException.getException(ResourceException.FORBIDDEN, result.getReason());
+            final ResourceException e = ResourceException.newResourceException(ResourceException.FORBIDDEN, result.getReason());
             e.setDetail(result.getDetail());
             return e;
         }

--- a/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/OAuth2CrestAuthorizationModule.java
+++ b/commons/auth-filters/authz-filter/modules/oauth2-module/src/main/java/org/forgerock/authz/modules/oauth2/OAuth2CrestAuthorizationModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.authz.modules.oauth2;
@@ -223,7 +224,7 @@ public class OAuth2CrestAuthorizationModule implements CrestAuthorizationModule 
                     }, new AsyncFunction<AuthorizationException, AuthorizationResult, ResourceException>() {
                         @Override
                         public Promise<AuthorizationResult, ResourceException> apply(AuthorizationException e) {
-                            return Promises.newExceptionPromise(ResourceException.getException(
+                            return Promises.newExceptionPromise(ResourceException.newResourceException(
                                     ResourceException.INTERNAL_ERROR, e.getMessage(), e));
                         }
                     }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/BackstageMojo.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/BackstageMojo.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.doc.maven;
@@ -28,6 +29,7 @@ import org.forgerock.json.fluent.JsonValue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 
 /**
@@ -113,7 +115,7 @@ public class BackstageMojo extends AbstractDocbkxMojo {
                 .add("released", getReleaseDate());
         final File file = new File(getBackstageDirectory(), "docset.json");
         try {
-            FileUtils.writeStringToFile(file, jsonValue.toString());
+            FileUtils.writeStringToFile(file, jsonValue.toString(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new MojoFailureException("Failed to write :" + file.getPath());
         }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/backstage/ArtifactDocs.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/backstage/ArtifactDocs.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.doc.maven.backstage;
@@ -23,6 +24,7 @@ import org.forgerock.doc.maven.AbstractDocbkxMojo;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Unpack documentation artifacts and prepare them for Backstage.
@@ -94,7 +96,7 @@ public class ArtifactDocs {
         final String json = "{\"title\":\"" + title + "\"}";
         final File file = new File(directory, "meta.json");
         try {
-            FileUtils.writeStringToFile(file, json);
+            FileUtils.writeStringToFile(file, json, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to write :" + file.getPath());
         }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
@@ -134,7 +134,7 @@ public class Html {
         final URL scriptUrl = Html.class.getResource("/js/" + m.getJavaScriptFileName());
         String scriptString;
         try {
-            scriptString = IOUtils.toString(scriptUrl);
+            scriptString = IOUtils.toString(scriptUrl, StandardCharsets.UTF_8);
         } catch (IOException ie) {
             throw new MojoExecutionException("Failed to read " + scriptUrl, ie);
         }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/CreateThumbs.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/CreateThumbs.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.doc.maven.pre;
@@ -62,7 +63,7 @@ public class CreateThumbs {
 
             for (File image : FileUtils.listFiles(
                     m.getDocbkxModifiableSourcesDirectory(),
-                    new WildcardFileFilter("*.png"),
+                    WildcardFileFilter.builder().setWildcards("*.png").get(),
                     TrueFileFilter.INSTANCE)) {
                 PngUtils.resizePng(image);
             }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/Dpi.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/Dpi.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2014 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.doc.maven.pre;
@@ -61,7 +62,7 @@ public class Dpi {
 
             for (File image : FileUtils.listFiles(
                     m.getDocbkxModifiableSourcesDirectory(),
-                    new WildcardFileFilter("*.png"),
+                    WildcardFileFilter.builder().setWildcards("*.png").get(),
                     TrueFileFilter.INSTANCE)) {
                 PngUtils.setSafeDpi(image, m.getMaxImageHeightInInches());
             }

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/utils/HtmlUtils.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/utils/HtmlUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.doc.maven.utils;
@@ -24,6 +25,7 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,7 @@ public final class HtmlUtils {
             throw new IOException(cssFile.getPath() + " not found");
         }
 
-        final String cssString = FileUtils.readFileToString(cssFile);
+        final String cssString = FileUtils.readFileToString(cssFile, StandardCharsets.UTF_8);
 
         Set<String> docNames = NameUtils.getDocumentNames(
                 srcDir, documentSrcName);
@@ -90,10 +92,10 @@ public final class HtmlUtils {
             final File xmlFile = new File(parent, cssFile.getName() + ".xml");
 
             if (!xmlFile.exists()) { // Do not append the document again to the same file.
-                FileUtils.write(xmlFile, "<?xml version=\"1.0\"?>\n", true);
-                FileUtils.write(xmlFile, "<style>\n", true);
-                FileUtils.write(xmlFile, cssString, true);
-                FileUtils.write(xmlFile, "</style>\n", true);
+                FileUtils.write(xmlFile, "<?xml version=\"1.0\"?>\n", StandardCharsets.UTF_8, true);
+                FileUtils.write(xmlFile, "<style>\n", StandardCharsets.UTF_8, true);
+                FileUtils.write(xmlFile, cssString, StandardCharsets.UTF_8, true);
+                FileUtils.write(xmlFile, "</style>\n", StandardCharsets.UTF_8, true);
             }
         }
     }

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/BranchingStreamWrapper.java
@@ -208,7 +208,6 @@ final class BranchingStreamWrapper extends BranchingInputStream {
         } catch (IOException ioe) {
             // inappropriate to throw an exception when object is being collected
         }
-        super.finalize();
     }
 
     /**

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/FileBuffer.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/FileBuffer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.http.io;
@@ -122,7 +123,6 @@ final class FileBuffer implements Buffer {
         } catch (IOException ioe) {
             // inappropriate to throw an exception when object is being collected
         }
-        super.finalize();
     }
 
     /**

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/io/MemoryBuffer.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/io/MemoryBuffer.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.http.io;
@@ -112,7 +113,6 @@ final class MemoryBuffer implements Buffer {
     @Override
     public void finalize() throws Throwable {
         close();
-        super.finalize();
     }
 
     /**

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/util/Loader.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/util/Loader.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2010–2011 ApexIdentity Inc.
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.http.util;
@@ -67,7 +68,7 @@ public final class Loader {
      */
     public static Object newInstance(String name) {
         try {
-            return getClass(name).newInstance();
+            return getClass(name).getDeclaredConstructor().newInstance();
         } catch (Throwable t) {
             return null;
         }

--- a/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
+++ b/commons/httpdump/src/main/java/ru/org/openam/httpdump/BufferedRequestWrapper.java
@@ -29,7 +29,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +44,8 @@ public class BufferedRequestWrapper extends HttpServletRequestWrapper {
 
     private void readBody() {
         if (body == null
-                && !StringUtils.containsIgnoreCase(getContentType(), "application/x-www-form-urlencoded")
-                && !StringUtils.containsIgnoreCase(getContentType(), "multipart/form-data")
+                && !Strings.CI.contains(getContentType(), "application/x-www-form-urlencoded")
+                && !Strings.CI.contains(getContentType(), "multipart/form-data")
         )
             try {
                 InputStream is = super.getInputStream();

--- a/commons/json-ref/core/src/main/java/org/forgerock/json/ref/JsonReference.java
+++ b/commons/json-ref/core/src/main/java/org/forgerock/json/ref/JsonReference.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.json.ref;
@@ -20,6 +21,7 @@ import java.net.URI;
 import java.util.HashMap;
 
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueFunctions;
 import org.forgerock.json.JsonValueException;
 
 /**
@@ -85,7 +87,7 @@ public class JsonReference {
      * @throws NullPointerException if {@code value} is {@code null}.
      */
     public JsonReference fromJsonValue(JsonValue value) throws JsonValueException {
-        this.uri = value.get("$ref").required().asURI();
+        this.uri = value.get("$ref").required().as(JsonValueFunctions.uri());
         return this;
     }
 

--- a/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
+++ b/commons/json-schema/cli/src/main/java/org/forgerock/json/schema/Main.java
@@ -37,6 +37,7 @@ import java.util.Scanner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueFunctions;
 import org.forgerock.json.schema.validator.Constants;
 import org.forgerock.json.schema.validator.ErrorHandler;
 import org.forgerock.json.schema.validator.FailFastErrorHandler;
@@ -189,7 +190,7 @@ public final class Main {
         try (final FileInputStream in = new FileInputStream(schemaFile)) {
             schemaMap = new JsonValue(MAPPER.readValue(in, Map.class));
         }
-        URI id = schemaMap.get(Constants.ID).required().asURI();
+        URI id = schemaMap.get(Constants.ID).required().as(JsonValueFunctions.uri());
         Validator v = ObjectValidatorFactory.getTypeValidator(schemaMap.asMap());
         if (!id.isAbsolute()) {
             id = base.resolve(id);
@@ -248,7 +249,7 @@ public final class Main {
     //Validation
 
     private void validate(JsonValue value) throws SchemaException, URISyntaxException {
-        URI schemaId = value.get(Constants.SCHEMA).asURI();
+        URI schemaId = value.get(Constants.SCHEMA).as(JsonValueFunctions.uri());
         if (null == schemaId && isEmptyOrBlank(schemaURI)) {
             System.out.println("-i (--id) must be an URI");
             return;

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestArraySchema.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestArraySchema.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.api.jackson;
@@ -40,7 +41,7 @@ import org.forgerock.api.enums.WritePolicy;
 public class CrestArraySchema extends ArraySchema implements CrestReadWritePoliciesSchema, OrderedFieldSchema,
         ValidatableSchema, WithExampleSchema<List<Object>> {
     private static final JavaType EXAMPLE_VALUE_TYPE = OBJECT_MAPPER.getTypeFactory()
-            .constructParametrizedType(ArrayList.class, List.class, Object.class);
+            .constructParametricType(ArrayList.class, Object.class);
 
     private WritePolicy writePolicy;
     private ReadPolicy readPolicy;

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestObjectSchema.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/CrestObjectSchema.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.api.jackson;
@@ -43,7 +44,7 @@ import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
 public class CrestObjectSchema extends ObjectSchema implements CrestReadWritePoliciesSchema, OrderedFieldSchema,
         ValidatableSchema, RequiredFieldsSchema, WithExampleSchema<Map<String, Object>> {
     private static final JavaType EXAMPLE_VALUE_TYPE = OBJECT_MAPPER.getTypeFactory()
-            .constructParametrizedType(HashMap.class, Map.class, String.class, Object.class);
+            .constructParametricType(HashMap.class, String.class, Object.class);
     private WritePolicy writePolicy;
     private ReadPolicy readPolicy;
     private Boolean errorOnWritePolicyFailure;

--- a/commons/rest/json-resource-examples/src/main/java/org/forgerock/json/resource/http/examples/CrestHttpApplication.java
+++ b/commons/rest/json-resource-examples/src/main/java/org/forgerock/json/resource/http/examples/CrestHttpApplication.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.json.resource.http.examples;
@@ -24,8 +25,8 @@ import static org.forgerock.json.resource.RouteMatchers.*;
 import static org.forgerock.json.resource.http.CrestHttp.*;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
 import org.asciidoctor.Placement;
 import org.asciidoctor.SafeMode;
 import org.forgerock.api.markup.ApiDocGenerator;
@@ -100,15 +101,15 @@ public class CrestHttpApplication implements DescribedHttpApplication {
                         final String html;
                         synchronized (asciidoctor) {
                             html = asciidoctor.convert(asciiDocMarkup,
-                                    OptionsBuilder.options()
-                                            .attributes(AttributesBuilder.attributes()
+                                    Options.builder()
+                                            .attributes(Attributes.builder()
                                                     .tableOfContents(Placement.LEFT)
                                                     .sectNumLevels(5)
                                                     .attribute("toclevels", 5)
-                                                    .get())
+                                                    .build())
                                             .safe(SafeMode.SAFE)
                                             .headerFooter(true)
-                                            .get());
+                                            .build());
                         }
 
                         final Response response = new Response(Status.OK);

--- a/commons/selfservice/core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
+++ b/commons/selfservice/core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
@@ -18,6 +18,7 @@ package org.forgerock.selfservice.core.config;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -40,7 +41,7 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 class ClassNameFallbackPropertyTypeDeserializer extends AsPropertyTypeDeserializer {
     public ClassNameFallbackPropertyTypeDeserializer(JavaType bt, TypeIdResolver idRes, String typePropertyName,
             boolean typeIdVisible, JavaType defaultImpl) {
-        super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl);
+        super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl, JsonTypeInfo.As.PROPERTY);
     }
 
     public ClassNameFallbackPropertyTypeDeserializer(AsPropertyTypeDeserializer src, BeanProperty property) {
@@ -93,7 +94,7 @@ class ClassNameFallbackPropertyTypeDeserializer extends AsPropertyTypeDeserializ
                         return deser.deserialize(newParser, context);
                     }
                 } catch (Exception ex) {
-                    throw new JsonMappingException("Unable to load class for " + node.toString(), ex);
+                    throw JsonMappingException.from(jsonParser, "Unable to load class for " + node.toString(), ex);
                 }
             }
 

--- a/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleSelfServiceApplication.java
+++ b/commons/selfservice/example/src/main/java/org/forgerock/selfservice/example/ExampleSelfServiceApplication.java
@@ -38,6 +38,7 @@ import org.forgerock.json.resource.RequestHandler;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.Resources;
 import org.forgerock.json.resource.Router;
+import org.forgerock.json.resource.Applications;
 import org.forgerock.json.resource.http.CrestHttp;
 import org.forgerock.selfservice.core.UserUpdateService;
 import org.forgerock.selfservice.json.JsonAnonymousProcessServiceBuilder;
@@ -71,7 +72,7 @@ public final class ExampleSelfServiceApplication implements HttpApplication {
 
             org.forgerock.http.routing.Router chfRouter = new org.forgerock.http.routing.Router();
             chfRouter.addRoute(requestUriMatcher(RoutingMode.STARTS_WITH, "internal"),
-                    CrestHttp.newHttpHandler(crestConnectionFactory));
+                    CrestHttp.newHttpHandler(Applications.simpleCrestApplication(crestConnectionFactory, null, null)));
             chfRouter.addRoute(requestUriMatcher(RoutingMode.STARTS_WITH, "reset"), registerResetHandler());
             chfRouter.addRoute(requestUriMatcher(RoutingMode.STARTS_WITH, "username"), registerUsernameHandler());
             chfRouter.addRoute(requestUriMatcher(RoutingMode.STARTS_WITH, "registration"),
@@ -99,7 +100,7 @@ public final class ExampleSelfServiceApplication implements HttpApplication {
                 .withProcessStore(new SimpleInMemoryStore())
                 .build();
 
-        return CrestHttp.newHttpHandler(Resources.newInternalConnectionFactory(service));
+        return CrestHttp.newHttpHandler(Applications.simpleCrestApplication(Resources.newInternalConnectionFactory(service), null, null));
     }
 
     private Handler registerResetHandler() throws Exception {
@@ -115,8 +116,8 @@ public final class ExampleSelfServiceApplication implements HttpApplication {
     }
 
     private Handler registerUserKBAUpdateHandler() {
-        return CrestHttp.newHttpHandler(Resources.newInternalConnectionFactory(Resources.newCollection(
-                new UserUpdateService(crestConnectionFactory, resourcePath("users"), new JsonPointer("kbaInfo")))));
+        return CrestHttp.newHttpHandler(Applications.simpleCrestApplication(Resources.newInternalConnectionFactory(Resources.newHandler(
+                new UserUpdateService(crestConnectionFactory, resourcePath("users"), new JsonPointer("kbaInfo")))), null, null));
     }
 
     @Override

--- a/commons/selfservice/json/src/main/java/org/forgerock/selfservice/json/StorageTypeDeserializer.java
+++ b/commons/selfservice/json/src/main/java/org/forgerock/selfservice/json/StorageTypeDeserializer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.selfservice.json;
 
@@ -39,7 +40,7 @@ class StorageTypeDeserializer extends JsonDeserializer<StorageType> {
             return type;
         }
 
-        throw new JsonMappingException("Invalid value for type 'StorageType'");
+        throw JsonMappingException.from(jsonParser, "Invalid value for type 'StorageType'");
     }
 
 }

--- a/commons/selfservice/stages/src/main/java/org/forgerock/selfservice/stages/tokenhandlers/JwtTokenHandler.java
+++ b/commons/selfservice/stages/src/main/java/org/forgerock/selfservice/stages/tokenhandlers/JwtTokenHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.selfservice.stages.tokenhandlers;
@@ -100,7 +101,7 @@ public final class JwtTokenHandler implements SnapshotTokenHandler {
                         .enc(jweMethod)
                         .done()
                     .claims(claimsSet)
-                    .sign(jwsHandler, jwsAlgorithm)
+                    .signedWith(jwsHandler, jwsAlgorithm)
                     .build();
         } catch (JwtRuntimeException jwtRE) {
             throw new InternalServerErrorException("Error constructing snapshot token", jwtRE);

--- a/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.util.time;
@@ -104,6 +105,16 @@ public class Duration implements Comparable<Duration> {
      */
     @Deprecated
     public Duration(final Long number, final TimeUnit unit) {
+        this(number.longValue(), unit);
+    }
+
+    /**
+     * Builds a new {@code Duration}.
+     *
+     * @param number number of time unit.
+     * @param unit TimeUnit to express the duration in (cannot be {@literal null}).
+     */
+    private Duration(final long number, final TimeUnit unit) {
         Reject.ifTrue(number < 0, "Negative durations are not supported");
         this.number = number;
         this.unit = checkNotNull(unit);
@@ -177,7 +188,7 @@ public class Duration implements Comparable<Duration> {
                 unitSB.append(fragment.charAt(i));
                 i++;
             }
-            Long number = Long.valueOf(numberSB.toString());
+            long number = Long.parseLong(numberSB.toString());
             TimeUnit unit = parseTimeUnit(unitSB.toString());
 
             composite.add(new Duration(number, unit));

--- a/commons/util/util/src/main/java/org/forgerock/util/xml/XMLUtils.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/xml/XMLUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.util.xml;
@@ -49,7 +50,7 @@ public final class XMLUtils {
         Object securityManager = null;
         try {
             Class<?> securityManagerClass = Class.forName("org.apache.xerces.util.SecurityManager");
-            securityManager = securityManagerClass.newInstance();
+            securityManager = securityManagerClass.getDeclaredConstructor().newInstance();
             Method setEntityExpansionLimit = securityManagerClass.getMethod("setEntityExpansionLimit", int.class);
             setEntityExpansionLimit.invoke(securityManager, ENTITY_EXP_LIMIT);
         } catch (ClassNotFoundException ex) {

--- a/guice/test/src/main/java/org/forgerock/guice/core/GuiceTestCase.java
+++ b/guice/test/src/main/java/org/forgerock/guice/core/GuiceTestCase.java
@@ -51,7 +51,7 @@ public abstract class GuiceTestCase implements Module {
         GuiceModules guiceModules = this.getClass().getAnnotation(GuiceModules.class);
         if (guiceModules != null) {
             for (Class<? extends Module> moduleType : guiceModules.value()) {
-                modules.add(moduleType.newInstance());
+                modules.add(moduleType.getDeclaredConstructor().newInstance());
             }
         }
 

--- a/persistit/core/src/main/java/com/persistit/Buffer.java
+++ b/persistit/core/src/main/java/com/persistit/Buffer.java
@@ -4281,7 +4281,7 @@ public class Buffer extends SharedResource {
             IV.putHandle(bb, volumeHandle);
             IV.putVolumeId(bb, volume.getId());
             IV.putTimestamp(bb, 0);
-            if (_persistit.getConfiguration().isUseOldVSpec()) {
+            if (_persistit.getConfiguration().isUseOldVSpecInternal()) {
                 IV.putVolumeSpecification(bb, volume.getName());
             } else {
                 IV.putVolumeSpecification(bb, volume.getSpecification().toString());

--- a/persistit/core/src/main/java/com/persistit/Configuration.java
+++ b/persistit/core/src/main/java/com/persistit/Configuration.java
@@ -828,7 +828,7 @@ public class Configuration {
         setSysVolume(getProperty(SYSTEM_VOLUME_PROPERTY_NAME, DEFAULT_SYSTEM_VOLUME_NAME));
         setBufferInventoryEnabled(getBooleanProperty(BUFFER_INVENTORY_PROPERTY_NAME, false));
         setBufferPreloadEnabled(getBooleanProperty(BUFFER_PRELOAD_PROPERTY_NAME, false));
-        setUseOldVSpec(getBooleanProperty(USE_OLD_VSPEC, false));
+        useOldVSpec = getBooleanProperty(USE_OLD_VSPEC, false);
 
         loadPropertiesBufferSpecifications();
         loadPropertiesVolumeSpecifications();
@@ -2093,6 +2093,10 @@ public class Configuration {
      */
     @Deprecated
     public boolean isUseOldVSpec() {
+        return useOldVSpec;
+    }
+
+    boolean isUseOldVSpecInternal() {
         return useOldVSpec;
     }
 

--- a/persistit/core/src/main/java/com/persistit/DefaultObjectCoder.java
+++ b/persistit/core/src/main/java/com/persistit/DefaultObjectCoder.java
@@ -463,7 +463,7 @@ public class DefaultObjectCoder extends DefaultValueCoder implements KeyRenderer
                     + " does not match requested class " + clazz.getName());
         Object instance;
         try {
-            instance = getClientClass().newInstance();
+            instance = getClientClass().getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new ConversionException("Unable to instantiate an instance of " + getClientClass(), e);
 

--- a/persistit/core/src/main/java/com/persistit/DefaultValueCoder.java
+++ b/persistit/core/src/main/java/com/persistit/DefaultValueCoder.java
@@ -989,7 +989,7 @@ public class DefaultValueCoder implements ValueRenderer, HandleCache {
             if (_newInstanceMethod != null) {
                 return _newInstanceMethod.invoke(_classDescriptor, _newInstanceArguments);
             } else {
-                return _clazz.newInstance();
+                return _clazz.getDeclaredConstructor().newInstance();
             }
         } catch (final Exception e) {
             throw new ConversionException("Instantiating " + _clazz.getName(), e);

--- a/persistit/core/src/main/java/com/persistit/Exchange.java
+++ b/persistit/core/src/main/java/com/persistit/Exchange.java
@@ -4563,7 +4563,7 @@ public class Exchange implements ReadOnlyExchange {
    *
    */
   public void setMaximumValueSize(int size) {
-    _value.setMaximumSize(size);
-    _spareValue.setMaximumSize(size);
+    _value.setMaximumSizeInternal(size);
+    _spareValue.setMaximumSizeInternal(size);
   }
 }

--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -1167,7 +1167,7 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
         IV.putHandle(_writeBuffer, handle);
         IV.putVolumeId(_writeBuffer, volume.getId());
         JournalRecord.putTimestamp(_writeBuffer, epochalTimestamp());
-        if (_persistit.getConfiguration().isUseOldVSpec()) {
+        if (_persistit.getConfiguration().isUseOldVSpecInternal()) {
             IV.putVolumeSpecification(_writeBuffer, volume.getName());
         } else {
             IV.putVolumeSpecification(_writeBuffer, volume.getSpecification().toString());

--- a/persistit/core/src/main/java/com/persistit/Persistit.java
+++ b/persistit/core/src/main/java/com/persistit/Persistit.java
@@ -66,6 +66,7 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -2324,7 +2325,13 @@ public class Persistit {
     ClassNotFoundException, RemoteException {
     if (_localGUI == null) {
       _logBase.startAdminUI.log();
-      _localGUI = (UtilControl) (Class.forName(PERSISTIT_GUI_CLASS_NAME)).newInstance();
+      try {
+        _localGUI = (UtilControl) Class.forName(PERSISTIT_GUI_CLASS_NAME).getDeclaredConstructor().newInstance();
+      } catch (final NoSuchMethodException | InvocationTargetException e) {
+        final InstantiationException instantiationException = new InstantiationException(e.toString());
+        instantiationException.initCause(e);
+        throw instantiationException;
+      }
     }
     _localGUI.setManagement(getManagement());
     _suspendShutdown.set(suspendShutdown);

--- a/persistit/core/src/main/java/com/persistit/RecoveryManager.java
+++ b/persistit/core/src/main/java/com/persistit/RecoveryManager.java
@@ -1586,7 +1586,7 @@ public class RecoveryManager implements RecoveryManagerMXBean, VolumeHandleLooku
         final long startAddress = page;
         value.clear();
         if (size > value.getMaximumSize()) {
-            value.setMaximumSize(size);
+            value.setMaximumSizeInternal(size);
         }
         value.ensureFit(size);
 

--- a/persistit/core/src/main/java/com/persistit/Value.java
+++ b/persistit/core/src/main/java/com/persistit/Value.java
@@ -704,7 +704,7 @@ public final class Value {
     Debug.$assert0.t(!isLongRecordMode());
     Debug.$assert0.t(!target.isLongRecordMode());
 
-    target.setMaximumSize(_maximumSize);
+    target.setMaximumSizeInternal(_maximumSize);
     target.ensureFit(_size);
     System.arraycopy(_bytes, 0, target._bytes, 0, _size);
     target._size = _size;
@@ -912,6 +912,10 @@ public final class Value {
    */
   @Deprecated
   public void setMaximumSize(final int size) {
+    setMaximumSizeInternal(size);
+  }
+
+  void setMaximumSizeInternal(final int size) {
     if (size < _size) {
       throw new IllegalArgumentException("Value is larger than new maximum size");
     }

--- a/persistit/core/src/main/java/com/persistit/encoding/CollectionValueCoder.java
+++ b/persistit/core/src/main/java/com/persistit/encoding/CollectionValueCoder.java
@@ -163,14 +163,12 @@ public class CollectionValueCoder implements ValueRenderer, ValueDisplayer {
     @Override
     public Object get(final Value value, final Class<?> clazz, final CoderContext context) throws ConversionException {
         try {
-            final Object target = clazz.newInstance();
+            final Object target = clazz.getDeclaredConstructor().newInstance();
             value.registerEncodedObject(target);
             render(value, target, clazz, context);
             return target;
-        } catch (final InstantiationException ce) {
-            throw new ConversionException(ce + " while decoding a Collection value");
-        } catch (final IllegalAccessException iae) {
-            throw new ConversionException(iae + " while decoding a Collection value");
+        } catch (final ReflectiveOperationException e) {
+            throw new ConversionException(e + " while decoding a Collection value");
         }
     }
 

--- a/persistit/examples/SimpleBench/SimpleBench.java
+++ b/persistit/examples/SimpleBench/SimpleBench.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2005-2012 Akiban Technologies, Inc.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +90,8 @@ public class SimpleBench {
         props.setProperty("journalpath", "${datapath}/sbdemo_journal");
 
         Persistit persistit = new Persistit();
-        persistit.initialize(props);
+        persistit.setProperties(props);
+        persistit.initialize();
 
         try {
             doBench(persistit, args);

--- a/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/AdminUI.java
@@ -465,7 +465,7 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
                         setPropertyMethod.invoke(null, new Object[] { propName, propValue });
                     }
                 }
-                final javax.swing.LookAndFeel lnf = (javax.swing.LookAndFeel) lnfClass.newInstance();
+                final javax.swing.LookAndFeel lnf = (javax.swing.LookAndFeel) lnfClass.getDeclaredConstructor().newInstance();
 
                 javax.swing.UIManager.setLookAndFeel(lnf);
                 lafLoaded = true;
@@ -588,7 +588,7 @@ public class AdminUI implements UtilControl, Runnable, AdminCommand {
             final String caption = st.nextToken();
             try {
                 final Class cl = Class.forName(className);
-                final AdminPanel panel = (AdminPanel) cl.newInstance();
+                final AdminPanel panel = (AdminPanel) cl.getDeclaredConstructor().newInstance();
                 panel.setup(this);
                 _tabbedPane.addTab(caption, panel);
             } catch (final Exception e) {

--- a/persistit/ui/src/main/java/com/persistit/ui/InspectorPanel.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/InspectorPanel.java
@@ -85,7 +85,7 @@ class InspectorPanel extends JPanel {
             final String caption = st.nextToken();
             try {
                 final Class cl = Class.forName(className);
-                final AbstractInspector panel = (AbstractInspector) cl.newInstance();
+                final AbstractInspector panel = (AbstractInspector) cl.getDeclaredConstructor().newInstance();
                 panel.setup(_adminUI, this);
                 _tabbedPane.addTab(caption, panel);
             } catch (final Exception e) {

--- a/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
+++ b/persistit/ui/src/main/java/com/persistit/ui/ManagementTableModel.java
@@ -381,7 +381,7 @@ public class ManagementTableModel extends AbstractTableModel {
         className = className.substring(0, className.lastIndexOf('.')) + ".renderers." + rendererName;
         try {
             final Class clazz = Class.forName(className);
-            final Object object = clazz.newInstance();
+            final Object object = clazz.getDeclaredConstructor().newInstance();
             if (object instanceof AbstractCustomTableCellRenderer) {
                 ((AbstractCustomTableCellRenderer) object).setup(_adminUI, infoClass, columnSpec);
                 return (TableCellRenderer) object;

--- a/script/common/src/main/java/org/forgerock/script/engine/Utils.java
+++ b/script/common/src/main/java/org/forgerock/script/engine/Utils.java
@@ -257,6 +257,6 @@ public class Utils {
         } catch (final Throwable tmp) {
             resourceResultCode = ResourceException.INTERNAL_ERROR;
         }
-        return ResourceException.getException(resourceResultCode, t.getMessage(), t);
+        return ResourceException.newResourceException(resourceResultCode, t.getMessage(), t);
     }
 }

--- a/script/common/src/main/java/org/forgerock/script/exception/ScriptThrownException.java
+++ b/script/common/src/main/java/org/forgerock/script/exception/ScriptThrownException.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.forgerock.json.resource.ResourceException.FIELD_CODE;
 import static org.forgerock.json.resource.ResourceException.FIELD_DETAIL;
 import static org.forgerock.json.resource.ResourceException.FIELD_MESSAGE;
-import static org.forgerock.json.resource.ResourceException.getException;
+import static org.forgerock.json.resource.ResourceException.newResourceException;
 
 /**
  * An exception that is thrown to indicate that an executed script encountered
@@ -129,17 +129,17 @@ public class ScriptThrownException extends ScriptException {
                 if (throwable == null) {
                     throwable = this;
                 }
-                return getException(openidmCode.intValue(), message, throwable).setDetail(
+                return newResourceException(openidmCode.intValue(), message, throwable).setDetail(
                         failureDetail);
 
             }
         }
         if (defaultMsg != null) {
-            return getException(defaultCode, defaultMsg, this);
+            return newResourceException(defaultCode, defaultMsg, this);
         } else if (value == null) {
-            return getException(defaultCode, null, this);
+            return newResourceException(defaultCode, null, this);
         } else {
-            return getException(defaultCode, String.valueOf(value), this);
+            return newResourceException(defaultCode, String.valueOf(value), this);
         }
     }
 

--- a/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
+++ b/script/common/src/main/java/org/forgerock/script/registry/ScriptRegistryImpl.java
@@ -28,6 +28,7 @@ package org.forgerock.script.registry;
 
 import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.JsonValueFunctions;
 import org.forgerock.script.Scope;
 import org.forgerock.script.Script;
 import org.forgerock.script.ScriptContext;
@@ -230,7 +231,7 @@ public class ScriptRegistryImpl implements ScriptRegistry, ScriptEngineFactoryOb
                 addSourceUnit(new EmbeddedScriptSource(source.asString(), scriptName));
             } else {
                 addSourceUnit(new EmbeddedScriptSource(visibility
-                        .asEnum(ScriptEntry.Visibility.class), source.asString(), scriptName));
+                        .as(JsonValueFunctions.enumConstant(ScriptEntry.Visibility.class)), source.asString(), scriptName));
             }
         }
         ScriptEntry scriptEntry = takeScript(scriptName);

--- a/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableList.java
+++ b/script/javascript/src/main/java/org/forgerock/script/javascript/ScriptableList.java
@@ -4,6 +4,7 @@
 
 /**
  * Portions Copyrighted 2012-2014 ForgeRock AS
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 package org.forgerock.script.javascript;
 
@@ -734,7 +735,7 @@ class ScriptableList extends IdScriptableObject implements Wrapper {
             long llength = scriptableList.getLength();
             int length = (int) llength;
             if (llength != length) {
-                throw Context.reportRuntimeError(ScriptRuntime.getMessage1(
+                throw Context.reportRuntimeError(ScriptRuntime.getMessageById(
                         "msg.arraylength.too.big", String.valueOf(llength)));
             }
             // if no args, use "," as separator


### PR DESCRIPTION
Migrate the 77 `java/deprecated-call` code scanning alerts to their recommended non-deprecated APIs. All replacements preserve existing behavior and the affected modules compile.

### Highlights
- `Class.newInstance()` → `getDeclaredConstructor().newInstance()`
- `ResourceException.getException` → `newResourceException`
- Commons IO `FileUtils`/`IOUtils` calls → explicit `StandardCharsets.UTF_8`; `new WildcardFileFilter(...)` → `WildcardFileFilter.builder()`
- `CrestHttp.newHttpHandler(ConnectionFactory)` → `newHttpHandler(Applications.simpleCrestApplication(factory, null, null))`
- `Duration(Long, TimeUnit)` internal uses → private `Duration(long, TimeUnit)`
- `Resources.newSingleton/newCollection` → `newHandler`
- asciidoctorj `OptionsBuilder.options()`/`AttributesBuilder.attributes()`/`get()` → `Options.builder()`/`Attributes.builder()`/`build()`
- `JsonValue.asURI()/asEnum()` → `as(JsonValueFunctions.uri()/enumConstant())`
- Jackson: `TypeFactory.constructParametrizedType` → `constructParametricType`; `new JsonMappingException(...)` → `JsonMappingException.from(parser, ...)`; `AsPropertyTypeDeserializer` 5-arg ctor → 6-arg
- persistit: `Value.setMaximumSize` / `Configuration.isUseOldVSpec` via package-private internals; `Persistit.initialize(Properties)` → `setProperties(props)` + `initialize()`
- `Object.finalize()` overrides → drop no-op `super.finalize()` (`close()` kept)
- `EncryptedJwtBuilder.sign` → `signedWith`
- `StringUtils.containsIgnoreCase` → `Strings.CI.contains`
- TestNG `ITestNGMethod.getInstances()` → `getInstance()`
- Rhino `ScriptRuntime.getMessage1` → `getMessageById`

### Intentionally left unchanged (8 alerts, dismissed)
A safe fix would change behavior or require a disproportionate migration for a note-level finding:
- io.swagger `Response.schema` (x3, would alter generated OpenAPI output)
- `Thread.stop` in the persistit inspector (deliberate runaway-thread termination, no cooperative equivalent)
- legacy `maven-external-dependency-plugin` Maven 2 API calls (`ArtifactResolver.resolve`, `WagonManager.getWagon`, `Archiver.addDirectory`)
