### PR TITLE
Remove always-false array-length check in ForgeRockTestListener

### DIFF
--- a/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
+++ b/build-tools/src/main/java/org/forgerock/testng/ForgeRockTestListener.java
@@ -449,14 +449,7 @@ public final class ForgeRockTestListener extends TestListenerAdapter implements 
     }
 
     private void checkForInterleavedBetweenClasses(final ITestResult tr) {
-        final Object[] testInstances = new Object[] { tr.getMethod().getInstance() };
-        // This will almost always have a single element. If it doesn't,
-        // just skip it.
-        if (testInstances.length != 1) {
-            return;
-        }
-
-        final Object testInstance = testInstances[0];
+        final Object testInstance = tr.getMethod().getInstance();
 
         // We're running another test on the same test object. Everything is
         // fine.


### PR DESCRIPTION
## Summary
Fixes a CodeQL `java/constant-comparison` alert ("Useless comparison test / Test is always false") in `ForgeRockTestListener.checkForInterleavedBetweenClasses`.

The method wrapped a single `ITestNGMethod.getInstance()` value into a one-element array literal and then tested `testInstances.length != 1` — a condition that can never be true, so the guard was dead code (likely a leftover from an earlier `getInstances()` array API).

## Change
- Use the single test instance directly.
- Drop the useless one-element array allocation and the always-false length comparison.

No behavior change: the length guard never protected anything since the array always had exactly one element.

Closes code scanning alert #2089.