### PR TITLE
Clean up CodeQL js/ warnings in commons UI

### DIFF
--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/components/Messages.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/components/Messages.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -103,7 +104,7 @@ define([
 
         showMessage: function() {
             var _this = this,
-                alertClass = "alert-info",
+                alertClass,
                 alertIcon = "alert-message-icon",
                 delay = _this.delay + (this.list[0].message.length * 20);
 

--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/main/ViewManager.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/main/ViewManager.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -118,7 +119,7 @@ define([
         var cDialog = obj.currentDialog, cDialogArgs = obj.currentDialogArgs;
 
         obj.changeView(obj.currentView, obj.currentViewArgs, function() {}, true);
-        if (cDialog && cDialog !== null) {
+        if (cDialog) {
             obj.showDialog(cDialog, cDialogArgs);
         }
     };

--- a/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
+++ b/ui/commons/src/main/js/org/forgerock/commons/ui/common/util/UIUtils.js
@@ -637,7 +637,7 @@ define([
          * @returns {Boolean}
          */
         "isUrl": function(string){
-            var regexp = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
+            var regexp = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@\-\/]))?/;
             return regexp.test(string);
         }
 

--- a/ui/commons/src/main/resources/templates/common/LoginTemplate.html
+++ b/ui/commons/src/main/resources/templates/common/LoginTemplate.html
@@ -1,4 +1,5 @@
 <!-- Copyright 2016 ForgeRock AS.
+	Portions Copyrighted 2026 3A Systems, LLC
 	License terms: https://forgerock.org/cddlv1-0/ -->
 <div class="container">
     <div class="row">
@@ -24,7 +25,7 @@
                     <div class="remember-forgot clearfix">
                         <div class="checkbox pull-left">
                             <label>
-                                <input type="checkbox" type="checkbox" name="loginRemember"> {{t "templates.user.LoginTemplate.loginRemember"}}
+                                <input type="checkbox" name="loginRemember"> {{t "templates.user.LoginTemplate.loginRemember"}}
                             </label>
                         </div>
                     </div>

--- a/ui/user/src/main/js/org/forgerock/commons/ui/user/profile/UserProfileKBATab.js
+++ b/ui/user/src/main/js/org/forgerock/commons/ui/user/profile/UserProfileKBATab.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 define([
@@ -127,7 +128,7 @@ define([
             }
 
             // validate form only in case security question was selected
-            if (!isKbaQuestion || (isKbaQuestion && (target.val() !== ""))) {
+            if (!isKbaQuestion || target.val() !== "") {
                 ValidatorsManager.bindValidators(form, Configuration.loggedUser.baseEntity, function () {
                     ValidatorsManager.validateAllFields(form);
                 });


### PR DESCRIPTION
## Summary
Resolves five CodeQL `js/` code-scanning alerts in first-party UI code. All changes are behavior-preserving cleanups of dead/redundant code.

| Alert | Rule | Fix |
|-------|------|-----|
| #2072 | `js/comparison-between-incompatible-types` | `ViewManager.js` — drop redundant `cDialog !== null` next to the truthiness check |
| #2070 | `js/duplicate-html-attribute` | `LoginTemplate.html` — remove duplicated `type="checkbox"` on the loginRemember input |
| #2068 | `js/useless-assignment-to-local` | `Messages.js` — drop unused initial `alert-info` value; the switch (with its `default`) always overwrites `alertClass` |
| #2053 | `js/regex/duplicate-in-character-class` | `UIUtils.js` — remove the repeated `!` in the `isUrl` regex character class |
| #2046 | `js/trivial-conditional` | `UserProfileKBATab.js` — simplify the always-true inner `isKbaQuestion` term in the KBA guard |

## Note
The remaining open `js/` alerts are all inside `commons/rest/openapi-war-overlay/` (vendored handlebars/marked/swagger-oauth) and are addressed by removing that module in a separate branch, so they are intentionally not touched here.