### PR TITLE
Clean up low-severity CodeQL code-quality alerts

### DIFF
--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
@@ -99,7 +99,7 @@ public class IWAModule implements AsyncServerAuthModule {
         String httpAuthorization = request.getHeaders().getFirst("Authorization");
 
         try {
-            if (httpAuthorization == null || "".equals(httpAuthorization)) {
+            if (httpAuthorization == null || httpAuthorization.isEmpty()) {
                 LOG.debug("IWAModule: Authorization Header NOT set in request.");
 
                 response.getHeaders().put("WWW-Authenticate", "Negotiate");

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
@@ -234,7 +234,7 @@ public class WDSSO {
         if (!returnRealm) {
             int index = user.indexOf("@");
             if (index != -1) {
-                userName = user.toString().substring(0, index);
+                userName = user.substring(0, index);
             }
         }
         return userName;

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -259,7 +259,7 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
      * @return <code>true</code> if the String is non-null and non-empty.
      */
     private boolean isEmpty(String s) {
-        return s == null || "".equals(s);
+        return s == null || s.isEmpty();
     }
 
     /**

--- a/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
@@ -253,7 +253,7 @@ public class OpenAMSessionModule implements AsyncServerAuthModule {
      * @return <code>true</code> if the String is non-null and non-empty.
      */
     private boolean isEmpty(String s) {
-        return s == null || "".equals(s);
+        return s == null || s.isEmpty();
     }
 
     /**

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/build/ChunkedHtml.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/build/ChunkedHtml.java
@@ -110,7 +110,6 @@ public class ChunkedHtml {
                 cfg.add(element(name("targetDirectory"), m.path(m.getDocbkxOutputDirectory()) + "/html"));
                 cfg.add(element(name("targetsFilename"), m.getDocumentSrcName() + ".html.target.db"));
 
-                final String base = FilenameUtils.getBaseName(m.getDocumentSrcName());
                //cfg.add(element(name("chunkBaseDir"), chunkBaseDir));
 
                 executeMojo(
@@ -148,7 +147,6 @@ public class ChunkedHtml {
 
                 cfg.add(element(name("includes"), docName + "/" + m.getDocumentSrcName()));
 
-                final String base = FilenameUtils.getBaseName(m.getDocumentSrcName());
                 //cfg.add(element(name("chunkBaseDir"), chunkBaseDir));
 
                 cfg.add(element(name("manifest"),

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
@@ -213,7 +213,7 @@ public class Html {
             String linkToJira = getLinkToJira();
 
             String gascript = "";
-            if(m.getGoogleAnalyticsId() != null && !"".equals(m.getGoogleAnalyticsId())) {
+            if(m.getGoogleAnalyticsId() != null && !m.getGoogleAnalyticsId().isEmpty()) {
                 gascript = IOUtils.toString(
                         Html.class.getResourceAsStream("/endbody-ga.txt"), StandardCharsets.UTF_8);
                 gascript = gascript.replace("ANALYTICS-ID", m.getGoogleAnalyticsId());

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
@@ -1018,10 +1018,10 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         } else if (isMap()) {
             sb.append("{ ");
             Map<Object, Object> map = (Map<Object, Object>)object;
-            for (Iterator<Object> i = map.keySet().iterator(); i.hasNext();) {
-                Object key = i.next();
-                sb.append('"').append(key.toString()).append("\": ");
-                sb.append(new JsonValue(map.get(key)).toString()); // recursion
+            for (Iterator<Map.Entry<Object, Object>> i = map.entrySet().iterator(); i.hasNext();) {
+                Map.Entry<Object, Object> entry = i.next();
+                sb.append('"').append(entry.getKey().toString()).append("\": ");
+                sb.append(new JsonValue(entry.getValue()).toString()); // recursion
                 if (i.hasNext()) {
                     sb.append(", ");
                 }

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
@@ -77,7 +77,7 @@ public abstract class JwtSecureHeader extends JwtHeader {
      * @param jwkSetUrl The JWK Set URL.
      */
     public void setJwkSetUrl(URL jwkSetUrl) {
-        put(JKU.value(), new String(jwkSetUrl.toString()));
+        put(JKU.value(), jwkSetUrl.toString());
     }
 
     /**
@@ -133,7 +133,7 @@ public abstract class JwtSecureHeader extends JwtHeader {
      * @param x509Url The X.509 URL.
      */
     public void setX509Url(URL x509Url) {
-        put(X5U.value(), new String(x509Url.toString()));
+        put(X5U.value(), x509Url.toString());
     }
 
     /**

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
@@ -627,7 +627,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
             File pFile = new File(propertyFile);
             if (!pFile.isAbsolute()) {
                 is =
-                        projectDirectory.resolve(propertyFile.toString()).toURL().openConnection()
+                        projectDirectory.resolve(propertyFile).toURL().openConnection()
                                 .getInputStream();
             } else {
                 is =  pFile.toURI().toURL().openConnection().getInputStream();

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.api;
@@ -75,7 +76,7 @@ public class CrestApiProducer implements ApiProducer<ApiDescription> {
         Paths.Builder paths = paths();
         Set<String> names = api.getPaths().getNames();
         for (String subpath : names) {
-            paths.put(subpath.equals("") ? parentPath : parentPath + "/" + subpath,
+            paths.put(subpath.isEmpty() ? parentPath : parentPath + "/" + subpath,
                     api.getPaths().get(subpath));
         }
         return createApi(api.getDefinitions(), api.getErrors(), api.getServices(), paths.build());

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
@@ -82,7 +82,7 @@ public final class MemoryBackend implements CollectionResourceProvider {
             final String[] splitKeys = split[1].split(",");
 
             for (String key : splitKeys) {
-                if (!key.equals("")) {
+                if (!key.isEmpty()) {
                     sortKeys.add(SortKey.valueOf(key));
                 }
             }

--- a/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
+++ b/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
@@ -1343,12 +1343,12 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         } else if (isMap()) {
             sb.append("{ ");
             final Map<Object, Object> map = (Map<Object, Object>) object;
-            for (final Iterator<Object> i = map.keySet().iterator(); i.hasNext();) {
-                final Object key = i.next();
+            for (final Iterator<Map.Entry<Object, Object>> i = map.entrySet().iterator(); i.hasNext();) {
+                final Map.Entry<Object, Object> entry = i.next();
                 sb.append('"');
-                appendEscapedString(sb, key.toString());
+                appendEscapedString(sb, entry.getKey().toString());
                 sb.append("\": ");
-                sb.append(new JsonValue(map.get(key)).toString()); // recursion
+                sb.append(new JsonValue(entry.getValue()).toString()); // recursion
                 if (i.hasNext()) {
                     sb.append(", ");
                 }

--- a/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
@@ -165,7 +165,7 @@ public class Duration implements Comparable<Duration> {
         for (String fragment : fragments) {
             fragment = fragment.trim();
 
-            if ("".equals(fragment)) {
+            if (fragment.isEmpty()) {
                 throw new IllegalArgumentException("Cannot parse empty duration, expecting '<value> <unit>' pattern");
             }
 

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
@@ -242,7 +242,7 @@ public class ArtifactItem
      */
     private String filterEmptyString(final String in)
     {
-        if (in == null || in.equals(""))
+        if (in == null || in.isEmpty())
         {
             return null;
         }

--- a/persistit/doc/build/src/AsciiDocIndex.java
+++ b/persistit/doc/build/src/AsciiDocIndex.java
@@ -177,7 +177,6 @@ public class AsciiDocIndex {
             }
 
             else {
-                final String className = href.substring(0, pHtml).replace('/', '.');
                 final String name = href.substring(pHash + 1);
                 final int pLeftParen = name.indexOf('(');
                 if (pLeftParen == -1) {


### PR DESCRIPTION
Resolves 17 open CodeQL `note`-level (code-quality) alerts across 15 files. All changes are behaviour-preserving mechanical cleanups.

## Fixes by rule

| Rule | Count | Change |
|------|-------|--------|
| `java/inefficient-empty-string-test` | 8 | `"".equals(x)` / `x.equals("")` → `x.isEmpty()` (each site already null-guards separately) |
| `java/inefficient-string-constructor` | 2 | drop redundant `new String(url.toString())` wrapper |
| `java/inefficient-key-set-iterator` | 2 | iterate `entrySet()` instead of `keySet()` + `get(key)` (identical output) |
| `java/useless-tostring-call` | 2 | remove `.toString()` on a value that is already a `String` |
| `java/local-variable-is-never-read` | 3 | remove dead local assignments |

## Intentionally left alone (not mechanical)

These open alerts are **not** included, as a "fix" would be wrong or would change behaviour:

- **`persistit/core/.../BufferPool.java:272`** (`local-variable-is-never-read`) — deliberate OOM reserve: the `byte[] reserve` block is nulled in the `catch` to free memory for the diagnostic path. Removing it would break the mechanism (false positive).
- **`rest/api-descriptor/.../CrestApiProducer.java:93`** (`call-to-object-tostring`) — no clean mechanical fix; a change would alter the text of a diagnostic exception message.
- **`persistit/doc/conf.py:14`** (`py/unused-import`) — `import sys, os` backs the commented Sphinx example on line 19; removing it would introduce a latent `NameError`.

## Verification

`mvn -o compile` passes for every touched Maven module; `AsciiDocIndex.java` (non-Maven doc tooling) compiles via `javac` with persistit-core on the classpath.
