### PR TITLE
[#300] Make BufferPool.get honor its timeout when allocating a buffer

### DIFF
--- a/persistit/core/src/main/java/com/persistit/BufferPool.java
+++ b/persistit/core/src/main/java/com/persistit/BufferPool.java
@@ -741,12 +741,13 @@ public class BufferPool {
      *            throwing an InUseException
      * @return Buffer The Buffer describing the buffer containing the page.
      * @throws InUseException
-     *             if the specific lock could not be acquired within the
-     *             specified timeout
+     *             if the specific lock could not be acquired or no buffer
+     *             could be allocated for the page within the specified timeout
      */
     Buffer get(final Volume vol, final long page, final boolean writer, final boolean wantRead, final long timeout)
             throws PersistitException {
         final int hash = hashIndex(vol, page);
+        final long start = System.currentTimeMillis();
         Buffer buffer = null;
 
         for (;;) {
@@ -782,34 +783,52 @@ public class BufferPool {
                     // in the page from the Volume.
                     //
                     buffer = allocBuffer();
-                    Debug.$assert1.t(!buffer.isDirty());
-                    Debug.$assert0.t(buffer != _hashTable[hash]);
-                    Debug.$assert0.t(buffer.getNext() != buffer);
+                    if (buffer != null) {
+                        Debug.$assert1.t(!buffer.isDirty());
+                        Debug.$assert0.t(buffer != _hashTable[hash]);
+                        Debug.$assert0.t(buffer.getNext() != buffer);
 
-                    buffer.setPageAddressAndVolume(page, vol);
-                    buffer.setNext(_hashTable[hash]);
-                    _hashTable[hash] = buffer;
-                    //
-                    // It's not really valid yet, but it does have a writer
-                    // claim on it so no other Thread can access it. In the
-                    // meantime, any other Thread seeking access to the same
-                    // page will find it.
-                    //
-                    buffer.setValid();
-                    if (vol.isTemporary() || vol.isLockVolume()) {
-                        buffer.setTemporary();
-                    } else {
-                        buffer.clearTemporary();
+                        buffer.setPageAddressAndVolume(page, vol);
+                        buffer.setNext(_hashTable[hash]);
+                        _hashTable[hash] = buffer;
+                        //
+                        // It's not really valid yet, but it does have a writer
+                        // claim on it so no other Thread can access it. In the
+                        // meantime, any other Thread seeking access to the same
+                        // page will find it.
+                        //
+                        buffer.setValid();
+                        if (vol.isTemporary() || vol.isLockVolume()) {
+                            buffer.setTemporary();
+                        } else {
+                            buffer.clearTemporary();
+                        }
+                        Debug.$assert0.t(buffer.getNext() != buffer);
                     }
-                    Debug.$assert0.t(buffer.getNext() != buffer);
                 }
             } finally {
                 _hashLocks[hash % HASH_LOCKS].unlock();
             }
+            if (buffer == null) {
+                /*
+                 * allocBuffer() swept the whole pool without finding an
+                 * evictable buffer. Wait for one to be released and retry the
+                 * search until the timeout budget expires. The wait must
+                 * happen here, after the finally block above has released the
+                 * hash lock, so that no thread sleeps while holding a lock
+                 * stripe.
+                 */
+                if (System.currentTimeMillis() - start >= timeout) {
+                    throw new InUseException("Thread " + Thread.currentThread().getName()
+                            + " failed to allocate a buffer for page " + page + " in " + vol + " within " + timeout
+                            + " ms");
+                }
+                Util.sleep(RETRY_SLEEP_TIME);
+                continue;
+            }
             if (mustClaim) {
                 boolean claimed = false;
                 boolean same = true;
-                final long start = System.currentTimeMillis();
                 while (same && !claimed && System.currentTimeMillis() - start < timeout) {
                     /*
                      * We're here because we found the page we want, but another
@@ -963,8 +982,6 @@ public class BufferPool {
      *         currently available. The buffer has a writer claim.
      * @throws PersistitException
      *             if a persistence error occurs while evicting a page
-     * @throws IllegalStateException
-     *             if there is no available buffer.
      */
 
     private Buffer allocBuffer() throws PersistitException {
@@ -1070,7 +1087,7 @@ public class BufferPool {
             }
             retry++;
         }
-        throw new IllegalStateException("No available Buffers");
+        return null;
     }
 
     enum Result {

--- a/persistit/core/src/test/java/com/persistit/BufferPoolTest.java
+++ b/persistit/core/src/test/java/com/persistit/BufferPoolTest.java
@@ -1,6 +1,8 @@
 /**
  * Copyright 2012 Akiban Technologies, Inc.
- * 
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,14 +19,22 @@
 package com.persistit;
 
 import com.persistit.BufferPool.BufferHolder;
+import com.persistit.exception.InUseException;
+import com.persistit.exception.PersistitException;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class BufferPoolTest extends PersistitUnitTestCase {
@@ -182,6 +192,113 @@ public class BufferPoolTest extends PersistitUnitTestCase {
             ex.to(j).fetch();
             assertEquals(j >= 1 && j <= i, ex.getValue().isDefined());
         }
+    }
+
+    /**
+     * When every buffer in the pool is claimed, get() for a page that is not
+     * in the pool must keep retrying the allocation until the caller's timeout
+     * budget expires and then throw a checked InUseException — not give up
+     * with a raw IllegalStateException after a single clock sweep (issue
+     * #300).
+     */
+    @Test
+    public void testGetHonorsTimeoutWhenPoolExhausted() throws Exception {
+        final Volume volume = _persistit.getVolume("persistit");
+        final BufferPool pool = volume.getPool();
+        final long timeout = 500;
+        final long[] pages = allocPages(volume, pool.getBufferCount() + 1);
+        final List<Buffer> claimed = new ArrayList<Buffer>();
+        try {
+            InUseException exhausted = null;
+            long elapsed = -1;
+            for (final long page : pages) {
+                final long start = System.currentTimeMillis();
+                try {
+                    claimed.add(pool.get(volume, page, true, false, timeout));
+                } catch (final InUseException e) {
+                    exhausted = e;
+                    elapsed = System.currentTimeMillis() - start;
+                    break;
+                }
+            }
+            assertNotNull("Claiming " + claimed.size() + " buffers of " + pool.getBufferCount()
+                    + " did not exhaust the pool", exhausted);
+            assertTrue("get() failed after " + elapsed + " ms, before its " + timeout + " ms timeout expired",
+                    elapsed >= timeout - 100);
+        } finally {
+            for (final Buffer buffer : claimed) {
+                buffer.release();
+            }
+        }
+    }
+
+    /**
+     * A get() that finds the pool exhausted must keep retrying and succeed as
+     * soon as another thread releases a buffer, rather than failing after a
+     * single sweep (issue #300).
+     */
+    @Test
+    public void testGetWaitsForReleasedBuffer() throws Exception {
+        final Volume volume = _persistit.getVolume("persistit");
+        final BufferPool pool = volume.getPool();
+        final long releaseDelay = 300;
+        final long[] pages = allocPages(volume, pool.getBufferCount() + 2);
+        final List<Buffer> claimed = new ArrayList<Buffer>();
+        try {
+            /*
+             * Require two consecutive allocation failures so that a single
+             * failure caused by a transient claim held by a background thread
+             * is not mistaken for pool exhaustion.
+             */
+            int consecutiveFailures = 0;
+            while (consecutiveFailures < 2 && claimed.size() <= pool.getBufferCount()) {
+                try {
+                    claimed.add(pool.get(volume, pages[claimed.size()], true, false, 100));
+                    consecutiveFailures = 0;
+                } catch (final InUseException expected) {
+                    consecutiveFailures++;
+                }
+            }
+            assertTrue("Claiming " + claimed.size() + " buffers of " + pool.getBufferCount()
+                    + " did not exhaust the pool", claimed.size() <= pool.getBufferCount());
+
+            final long page = pages[pages.length - 1];
+            final AtomicLong waited = new AtomicLong(-1);
+            final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+            final Thread getter = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    final long start = System.currentTimeMillis();
+                    try {
+                        final Buffer buffer = pool.get(volume, page, true, false, 10000);
+                        waited.set(System.currentTimeMillis() - start);
+                        buffer.release();
+                    } catch (final Throwable t) {
+                        failure.set(t);
+                    }
+                }
+            }, "BufferPoolTest_getter");
+            getter.start();
+            Thread.sleep(releaseDelay);
+            claimed.remove(claimed.size() - 1).release();
+            getter.join(30000);
+            assertTrue("Getter thread did not finish", !getter.isAlive());
+            assertNull("Getter thread failed: " + failure.get(), failure.get());
+            assertTrue("get() returned after " + waited.get() + " ms, before a buffer was released",
+                    waited.get() >= releaseDelay - 100);
+        } finally {
+            for (final Buffer buffer : claimed) {
+                buffer.release();
+            }
+        }
+    }
+
+    private long[] allocPages(final Volume volume, final int count) throws PersistitException {
+        final long[] pages = new long[count];
+        for (int i = 0; i < count; i++) {
+            pages[i] = volume.getStorage().allocNewPage();
+        }
+        return pages;
     }
 
 }


### PR DESCRIPTION
### Problem

`BufferPool.get()` honored its `timeout` budget only on the `mustClaim` path (claiming a buffer that already holds the wanted page). On a pool miss, `allocBuffer()` performed a single clock sweep of `2 × bufferCount` ticks and then threw a raw `IllegalStateException("No available Buffers")`. Sweep ticks are wasted on touched, claimed, or transiently non-detachable buffers, and the clock is shared, so concurrent sweepers race past each other's candidates — on a small hot pool a thread can stochastically burn its whole sweep and fail a plain read instead of waiting.

Surfaced by `TransactionTest2.transactionsWithInterrupts` on a `windows-latest` CI cell ([run 30011500179](https://github.com/OpenIdentityPlatform/commons/actions/runs/30011500179/job/89220489408#step:5:11042)): a worker died with `No available Buffers` during the 10-second interrupt storm against the 20-buffer test pool, tripping the worker-death assertion added in #288.

### Fix

- `allocBuffer()` returns `null` on sweep exhaustion — as its javadoc already promised — instead of throwing.
- `get()` retries the whole lookup with a short sleep (`RETRY_SLEEP_TIME`, 50 ms) until the timeout budget expires, then throws a checked `InUseException`, matching the method's documented contract. The sleep happens after the `finally` has released the hash-lock stripe, and each retry re-searches the hash table in case another thread loaded the page meanwhile.
- The claim path and the allocation path now share a single budget measured from `get()` entry, which also removes the old unbounded-wait pathology where every outer-loop `continue` restarted the `mustClaim` clock.

### Tests

- `testGetHonorsTimeoutWhenPoolExhausted` — with every buffer writer-claimed, `get()` for an absent page fails with `InUseException` and not before its timeout expires (the old behavior — an immediate `IllegalStateException` — fails both assertions).
- `testGetWaitsForReleasedBuffer` — a `get()` blocked on an exhausted pool succeeds as soon as another thread releases a buffer, and not earlier. Pool exhaustion is only declared after two consecutive allocation failures so a transient claim by a background thread is not mistaken for exhaustion.

Verified locally: `BufferPoolTest` (7/7), `TransactionTest2#transactionsWithInterrupts` plus related (4/4, balance agrees), `BufferTest`, `BufferTest2`, `BufferMaxPack`, `MVCCPruneBufferTest`, `VolumeTest` all green.

Fixes #300