### PR TITLE
Clean up low-severity CodeQL code-quality alerts

### DIFF
--- a/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/CsvAuditEventHandler.java
+++ b/commons/audit/handler-csv/src/main/java/org/forgerock/audit/handlers/csv/CsvAuditEventHandler.java
@@ -167,26 +167,26 @@ public class CsvAuditEventHandler extends AuditEventHandlerBase {
             }
         }
 
-        Map<String, Set<String>> fieldOrderByTopic = new HashMap<>();
-        Map<String, JsonPointer> jsonPointerByField = new HashMap<>();
-        Map<String, String> fieldDotNotationByField = new HashMap<>();
+        Map<String, Set<String>> orderByTopic = new HashMap<>();
+        Map<String, JsonPointer> pointerByField = new HashMap<>();
+        Map<String, String> dotNotationByField = new HashMap<>();
         for (String topic : this.eventTopicsMetaData.getTopics()) {
             try {
                 Set<String> fieldOrder = getFieldOrder(topic, this.eventTopicsMetaData);
                 for (String field : fieldOrder) {
-                    if (!jsonPointerByField.containsKey(field)) {
-                        jsonPointerByField.put(field, new JsonPointer(field));
-                        fieldDotNotationByField.put(field, jsonPointerToDotNotation(field));
+                    if (!pointerByField.containsKey(field)) {
+                        pointerByField.put(field, new JsonPointer(field));
+                        dotNotationByField.put(field, jsonPointerToDotNotation(field));
                     }
                 }
-                fieldOrderByTopic.put(topic, Collections.unmodifiableSet(fieldOrder));
+                orderByTopic.put(topic, Collections.unmodifiableSet(fieldOrder));
             } catch (ResourceException e) {
                 LOGGER.error(topic + " topic schema meta-data misconfigured.");
             }
         }
-        this.fieldOrderByTopic = Collections.unmodifiableMap(fieldOrderByTopic);
-        this.jsonPointerByField = Collections.unmodifiableMap(jsonPointerByField);
-        this.fieldDotNotationByField = Collections.unmodifiableMap(fieldDotNotationByField);
+        this.fieldOrderByTopic = Collections.unmodifiableMap(orderByTopic);
+        this.jsonPointerByField = Collections.unmodifiableMap(pointerByField);
+        this.fieldDotNotationByField = Collections.unmodifiableMap(dotNotationByField);
     }
 
     private CsvPreference createCsvPreference(final CsvAuditEventHandlerConfiguration config) {

--- a/commons/audit/handler-json/src/main/java/org/forgerock/audit/handlers/json/JsonFileWriter.java
+++ b/commons/audit/handler-json/src/main/java/org/forgerock/audit/handlers/json/JsonFileWriter.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.audit.handlers.json;
@@ -275,12 +276,12 @@ class JsonFileWriter {
             filesToDelete = new HashSet<>();
 
             // build map of topic files
-            final Map<String, TopicEntry> topicEntryMap = new HashMap<>();
+            final Map<String, TopicEntry> entriesByTopic = new HashMap<>();
             for (final String topic : topics) {
                 final String fileName = topic + '.' + fileNameSuffix;
-                topicEntryMap.put(topic, new TopicEntry(fileName, configuration));
+                entriesByTopic.put(topic, new TopicEntry(fileName, configuration));
             }
-            this.topicEntryMap = Collections.unmodifiableMap(topicEntryMap);
+            this.topicEntryMap = Collections.unmodifiableMap(entriesByTopic);
         }
 
         /**

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
@@ -99,7 +99,7 @@ public class IWAModule implements AsyncServerAuthModule {
         String httpAuthorization = request.getHeaders().getFirst("Authorization");
 
         try {
-            if (httpAuthorization == null || "".equals(httpAuthorization)) {
+            if (httpAuthorization == null || httpAuthorization.isEmpty()) {
                 LOG.debug("IWAModule: Authorization Header NOT set in request.");
 
                 response.getHeaders().put("WWW-Authenticate", "Negotiate");

--- a/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
@@ -234,7 +234,7 @@ public class WDSSO {
         if (!returnRealm) {
             int index = user.indexOf("@");
             if (index != -1) {
-                userName = user.toString().substring(0, index);
+                userName = user.substring(0, index);
             }
         }
         return userName;

--- a/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/jwt-session-module/src/main/java/org/forgerock/jaspi/modules/session/jwt/AbstractJwtSessionModule.java
@@ -259,7 +259,7 @@ abstract class AbstractJwtSessionModule<C extends JwtSessionCookie> {
      * @return <code>true</code> if the String is non-null and non-empty.
      */
     private boolean isEmpty(String s) {
-        return s == null || "".equals(s);
+        return s == null || s.isEmpty();
     }
 
     /**

--- a/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
+++ b/commons/auth-filters/authn-filter/jaspi-modules/openam-session-module/src/main/java/org/forgerock/jaspi/modules/session/openam/OpenAMSessionModule.java
@@ -253,7 +253,7 @@ public class OpenAMSessionModule implements AsyncServerAuthModule {
      * @return <code>true</code> if the String is non-null and non-empty.
      */
     private boolean isEmpty(String s) {
-        return s == null || "".equals(s);
+        return s == null || s.isEmpty();
     }
 
     /**

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/build/ChunkedHtml.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/build/ChunkedHtml.java
@@ -110,7 +110,6 @@ public class ChunkedHtml {
                 cfg.add(element(name("targetDirectory"), m.path(m.getDocbkxOutputDirectory()) + "/html"));
                 cfg.add(element(name("targetsFilename"), m.getDocumentSrcName() + ".html.target.db"));
 
-                final String base = FilenameUtils.getBaseName(m.getDocumentSrcName());
                //cfg.add(element(name("chunkBaseDir"), chunkBaseDir));
 
                 executeMojo(
@@ -148,7 +147,6 @@ public class ChunkedHtml {
 
                 cfg.add(element(name("includes"), docName + "/" + m.getDocumentSrcName()));
 
-                final String base = FilenameUtils.getBaseName(m.getDocumentSrcName());
                 //cfg.add(element(name("chunkBaseDir"), chunkBaseDir));
 
                 cfg.add(element(name("manifest"),

--- a/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
+++ b/commons/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/post/Html.java
@@ -213,7 +213,7 @@ public class Html {
             String linkToJira = getLinkToJira();
 
             String gascript = "";
-            if(m.getGoogleAnalyticsId() != null && !"".equals(m.getGoogleAnalyticsId())) {
+            if(m.getGoogleAnalyticsId() != null && !m.getGoogleAnalyticsId().isEmpty()) {
                 gascript = IOUtils.toString(
                         Html.class.getResourceAsStream("/endbody-ga.txt"), StandardCharsets.UTF_8);
                 gascript = gascript.replace("ANALYTICS-ID", m.getGoogleAnalyticsId());

--- a/commons/http-framework/core/src/main/java/org/forgerock/http/header/WarningHeader.java
+++ b/commons/http-framework/core/src/main/java/org/forgerock/http/header/WarningHeader.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.http.header;
@@ -159,9 +160,9 @@ public final class WarningHeader extends Header {
      * @param warning Single {@link Warning}
      */
     public WarningHeader(final Warning warning) {
-        final List<Warning> warnings = new ArrayList<>(1);
-        warnings.add(Reject.checkNotNull(warning));
-        this.warnings = Collections.unmodifiableList(warnings);
+        final List<Warning> warningList = new ArrayList<>(1);
+        warningList.add(Reject.checkNotNull(warning));
+        this.warnings = Collections.unmodifiableList(warningList);
     }
 
     /**

--- a/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
+++ b/commons/json-fluent/src/main/java/org/forgerock/json/fluent/JsonValue.java
@@ -1018,10 +1018,10 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         } else if (isMap()) {
             sb.append("{ ");
             Map<Object, Object> map = (Map<Object, Object>)object;
-            for (Iterator<Object> i = map.keySet().iterator(); i.hasNext();) {
-                Object key = i.next();
-                sb.append('"').append(key.toString()).append("\": ");
-                sb.append(new JsonValue(map.get(key)).toString()); // recursion
+            for (Iterator<Map.Entry<Object, Object>> i = map.entrySet().iterator(); i.hasNext();) {
+                Map.Entry<Object, Object> entry = i.next();
+                sb.append('"').append(entry.getKey().toString()).append("\": ");
+                sb.append(new JsonValue(entry.getValue()).toString()); // recursion
                 if (i.hasNext()) {
                     sb.append(", ");
                 }

--- a/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
+++ b/commons/json-web-token/src/main/java/org/forgerock/json/jose/jws/JwtSecureHeader.java
@@ -77,7 +77,7 @@ public abstract class JwtSecureHeader extends JwtHeader {
      * @param jwkSetUrl The JWK Set URL.
      */
     public void setJwkSetUrl(URL jwkSetUrl) {
-        put(JKU.value(), new String(jwkSetUrl.toString()));
+        put(JKU.value(), jwkSetUrl.toString());
     }
 
     /**
@@ -133,7 +133,7 @@ public abstract class JwtSecureHeader extends JwtHeader {
      * @param x509Url The X.509 URL.
      */
     public void setX509Url(URL x509Url) {
-        put(X5U.value(), new String(x509Url.toString()));
+        put(X5U.value(), x509Url.toString());
     }
 
     /**

--- a/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
+++ b/commons/launcher/launcher/src/main/java/org/forgerock/commons/launcher/OSGiFrameworkService.java
@@ -627,7 +627,7 @@ public class OSGiFrameworkService extends AbstractOSGiFrameworkService {
             File pFile = new File(propertyFile);
             if (!pFile.isAbsolute()) {
                 is =
-                        projectDirectory.resolve(propertyFile.toString()).toURL().openConnection()
+                        projectDirectory.resolve(propertyFile).toURL().openConnection()
                                 .getInputStream();
             } else {
                 is =  pFile.toURI().toURL().openConnection().getInputStream();

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
@@ -91,7 +91,8 @@ public class CrestApiProducer implements ApiProducer<ApiDescription> {
             if (singleton(UNVERSIONED).equals(versionedPath.getVersions())) {
                 paths.put(path, versionedPath().put(version, versionedPath.get(UNVERSIONED)).build());
             } else {
-                throw new IllegalStateException("Trying to version something already versioned: " + versionedPath);
+                throw new IllegalStateException(
+                        "Trying to version something already versioned: " + versionedPath.getVersions());
             }
         }
         return createApi(api.getDefinitions(), api.getErrors(), api.getServices(), paths.build());

--- a/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
+++ b/commons/rest/api-descriptor/src/main/java/org/forgerock/api/CrestApiProducer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC.
  */
 
 package org.forgerock.api;
@@ -75,7 +76,7 @@ public class CrestApiProducer implements ApiProducer<ApiDescription> {
         Paths.Builder paths = paths();
         Set<String> names = api.getPaths().getNames();
         for (String subpath : names) {
-            paths.put(subpath.equals("") ? parentPath : parentPath + "/" + subpath,
+            paths.put(subpath.isEmpty() ? parentPath : parentPath + "/" + subpath,
                     api.getPaths().get(subpath));
         }
         return createApi(api.getDefinitions(), api.getErrors(), api.getServices(), paths.build());

--- a/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
+++ b/commons/rest/json-resource/src/main/java/org/forgerock/json/resource/MemoryBackend.java
@@ -82,7 +82,7 @@ public final class MemoryBackend implements CollectionResourceProvider {
             final String[] splitKeys = split[1].split(",");
 
             for (String key : splitKeys) {
-                if (!key.equals("")) {
+                if (!key.isEmpty()) {
                     sortKeys.add(SortKey.valueOf(key));
                 }
             }

--- a/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
+++ b/commons/util/util/src/main/java/org/forgerock/json/JsonValue.java
@@ -1343,12 +1343,12 @@ public class JsonValue implements Cloneable, Iterable<JsonValue> {
         } else if (isMap()) {
             sb.append("{ ");
             final Map<Object, Object> map = (Map<Object, Object>) object;
-            for (final Iterator<Object> i = map.keySet().iterator(); i.hasNext();) {
-                final Object key = i.next();
+            for (final Iterator<Map.Entry<Object, Object>> i = map.entrySet().iterator(); i.hasNext();) {
+                final Map.Entry<Object, Object> entry = i.next();
                 sb.append('"');
-                appendEscapedString(sb, key.toString());
+                appendEscapedString(sb, entry.getKey().toString());
                 sb.append("\": ");
-                sb.append(new JsonValue(map.get(key)).toString()); // recursion
+                sb.append(new JsonValue(entry.getValue()).toString()); // recursion
                 if (i.hasNext()) {
                     sb.append(", ");
                 }

--- a/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
+++ b/commons/util/util/src/main/java/org/forgerock/util/time/Duration.java
@@ -165,7 +165,7 @@ public class Duration implements Comparable<Duration> {
         for (String fragment : fragments) {
             fragment = fragment.trim();
 
-            if ("".equals(fragment)) {
+            if (fragment.isEmpty()) {
                 throw new IllegalArgumentException("Cannot parse empty duration, expecting '<value> <unit>' pattern");
             }
 

--- a/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
+++ b/maven-external-dependency-plugin/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ArtifactItem.java
@@ -242,7 +242,7 @@ public class ArtifactItem
      */
     private String filterEmptyString(final String in)
     {
-        if (in == null || in.equals(""))
+        if (in == null || in.isEmpty())
         {
             return null;
         }

--- a/persistit/doc/build/src/AsciiDocIndex.java
+++ b/persistit/doc/build/src/AsciiDocIndex.java
@@ -177,7 +177,6 @@ public class AsciiDocIndex {
             }
 
             else {
-                final String className = href.substring(0, pHtml).replace('/', '.');
                 final String name = href.substring(pHash + 1);
                 final int pLeftParen = name.indexOf('(');
                 if (pLeftParen == -1) {

--- a/persistit/doc/conf.py
+++ b/persistit/doc/conf.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 #
+# Portions Copyrighted 2026 3A Systems, LLC.
+#
 # Persistit documentation build configuration file, created by
 # sphinx-quickstart on Fri May 18 15:19:04 2012.
 #
@@ -10,8 +12,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
Resolves a batch of CodeQL `note`-level (code-quality) alerts. No behaviour changes; all touched Java modules compile.

### Commit 1 — 17 alerts across 15 files
- **inefficient-empty-string-test** (8): use `String.isEmpty()` instead of `"".equals(...)`
- **inefficient-string-constructor** (2): drop redundant `new String(...)` wrappers
- **inefficient-key-set-iterator** (2): iterate `entrySet()` instead of `keySet()` + `get()`
- **useless-tostring-call** (2): remove `toString()` on values already `String`
- **local-variable-is-never-read** (3): remove dead local assignments

### Commit 2 — 7 alerts across 5 files
- **java/local-shadows-field** (5): rename local variables that shadowed fields in `CsvAuditEventHandler`, `JsonFileWriter`, and `WarningHeader`
- **java/call-to-object-tostring** (1): log `VersionedPath.getVersions()` instead of the object's default `toString()` in `CrestApiProducer`
- **py/unused-import** (1): drop the unused `import sys, os` in the persistit doc `conf.py`

### Not addressed here (deliberate)
- **java/class-name-matches-super-class** (2): renaming these public classes would break the API — dismissed as won't-fix
- **java/local-variable-is-never-read** (1): `BufferPool` keeps a 1 MB `reserve` buffer released on `OutOfMemoryError`; the "unused" write is intentional — dismissed as won't-fix
- **java/chained-type-tests** (2) in `Converter.java` left for a separate, dedicated refactor
