### PR TITLE
[#304] Throw PersistitClosedException when a commit races Persistit.close()

### DIFF
--- a/persistit/core/src/main/java/com/persistit/JournalManager.java
+++ b/persistit/core/src/main/java/com/persistit/JournalManager.java
@@ -61,6 +61,7 @@ import com.persistit.JournalRecord.TX;
 import com.persistit.Persistit.FatalErrorException;
 import com.persistit.TransactionPlayer.TransactionPlayerListener;
 import com.persistit.exception.CorruptJournalException;
+import com.persistit.exception.PersistitClosedException;
 import com.persistit.exception.PersistitException;
 import com.persistit.exception.PersistitIOException;
 import com.persistit.exception.PersistitInterruptedException;
@@ -1849,6 +1850,8 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
      *            complete the I/O when requested. In particular, a value of
      *            zero indicates the I/O should start immediately.
      * @throws PersistitInterruptedException if the thread is interrupted while waiting
+     * @throws PersistitClosedException if Persistit was closed or crashed before
+     *             durability could be confirmed
      */
 
     void waitForDurability(final long flushedTimestamp, final long leadTime, final long stallTime)
@@ -1857,7 +1860,7 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
         if (flusher != null) {
             flusher.waitForDurability(flushedTimestamp, leadTime, stallTime);
         } else {
-            throw new IllegalStateException("JOURNAL_FLUSHER is not running");
+            throw new PersistitClosedException("JOURNAL_FLUSHER is not running");
         }
     }
 
@@ -2347,6 +2350,21 @@ class JournalManager implements JournalManagerMXBean, VolumeHandleLookup {
                      * Done - commit is durable
                      */
                     break;
+                }
+
+                if (isStopped()) {
+                    /*
+                     * The flusher publishes its final _startTimestamp and
+                     * _endTimestamp before stopping, so one re-read after
+                     * observing the stop is exact: either the final flush
+                     * cycle covered flushedTimestamp, or no future cycle ever
+                     * will and polling would spin forever against a stopped
+                     * thread.
+                     */
+                    if (_endTimestamp > flushedTimestamp && _startTimestamp > flushedTimestamp) {
+                        break;
+                    }
+                    throw new PersistitClosedException("JOURNAL_FLUSHER stopped before durability was confirmed");
                 }
 
                 long remainingSleepNanos;

--- a/persistit/core/src/test/java/com/persistit/JournalManagerTest.java
+++ b/persistit/core/src/test/java/com/persistit/JournalManagerTest.java
@@ -22,6 +22,7 @@ import com.persistit.Accumulator.SumAccumulator;
 import com.persistit.CheckpointManager.Checkpoint;
 import com.persistit.JournalManager.PageNode;
 import com.persistit.TransactionPlayer.TransactionPlayerListener;
+import com.persistit.exception.PersistitClosedException;
 import com.persistit.exception.PersistitException;
 import com.persistit.unit.ConcurrentUtil.ThrowingRunnable;
 import com.persistit.util.Util;
@@ -676,6 +677,50 @@ public class JournalManagerTest extends PersistitUnitTestCase {
         addSchedules(PAGE_MAP_READ_INVALIDATE_SCHEDULE);
         startAndJoinAssertSuccess(25000, thread1, thread2);
         disableSequencer();
+    }
+
+    @Test
+    public void waitForDurabilityAfterCloseThrowsPersistitClosedException() throws Exception {
+        final JournalManager jman = _persistit.getJournalManager();
+        final long flushedTimestamp = _persistit.getTimestampAllocator().updateTimestamp();
+        _persistit.close();
+        try {
+            jman.waitForDurability(flushedTimestamp, 0, 0);
+            fail("Expected PersistitClosedException");
+        } catch (final PersistitClosedException expected) {
+            /*
+             * A commit racing Persistit.close() must observe the documented
+             * closed-state exception, not a raw IllegalStateException that
+             * bypasses callers' shutdown handling (issue #304).
+             */
+        }
+    }
+
+    @Test
+    public void waitForDurabilityOnStoppedFlusherThrowsInsteadOfSpinning() throws Exception {
+        final JournalManager jman = _persistit.getJournalManager();
+        _persistit.crash();
+        /*
+         * crash() stops JOURNAL_FLUSHER without clearing the JournalManager's
+         * reference to it, and a timestamp allocated after the flusher's final
+         * cycle can never be covered by its durability marks - the shape of
+         * the shutdown race in which a committing thread captured the flusher
+         * reference just before it was cleared. Without the stopped-flusher
+         * check this wait polls forever.
+         */
+        final long flushedTimestamp = _persistit.getTimestampAllocator().updateTimestamp();
+        final Thread waiter = createThread("WAIT_FOR_DURABILITY", new ThrowingRunnable() {
+            @Override
+            public void run() throws Exception {
+                try {
+                    jman.waitForDurability(flushedTimestamp, 0, 0);
+                    fail("Expected PersistitClosedException");
+                } catch (final PersistitClosedException expected) {
+                    // expected
+                }
+            }
+        });
+        startAndJoinAssertSuccess(10000, waiter);
     }
 
     private int countKeys(final boolean mvcc) throws PersistitException {


### PR DESCRIPTION
Fixes #304

### Problem

A transaction commit racing `Persistit.close()` has two failure windows in `JournalManager.waitForDurability`:

1. **Raw `IllegalStateException`**: `close()` nulls the `_flusher` reference before the committing thread reads it, so `waitForDurability` throws `IllegalStateException("JOURNAL_FLUSHER is not running")`. That is not a `PersistitException`, so callers' closed-state handling is bypassed — observed as the `TransactionTest2.transactionsConcurrentWithPersistitClose` flake on master run [30078532797](https://github.com/OpenIdentityPlatform/commons/actions/runs/30078532797/job/89434577777), where the worker landed in the test's `catch (Throwable)` branch and the stranded-thread assert failed.
2. **Infinite poll (latent)**: a committing thread that captures the flusher reference just before it is cleared enters the `JournalFlusher.waitForDurability` polling loop; once the flusher stops, its durability marks never advance, and a `flushedTimestamp` allocated after the flusher's final cycle can never be covered — the loop kicks a stopped thread forever. Confirmed real: the new test hangs past a 10-second join deadline without the fix.

### Fix

Throw `PersistitClosedException` in both windows:

- `JournalManager.waitForDurability` throws `PersistitClosedException` instead of `IllegalStateException` when the flusher reference is already null, so a commit racing `close()` unwinds through the same documented path as every other closed-state operation.
- The `JournalFlusher.waitForDurability` polling loop checks `isStopped()` after the success check. The flusher publishes its final `_startTimestamp`/`_endTimestamp` before stopping, so a single re-read after observing the stop is exact: either the final flush cycle covered the caller's timestamp (return success) or no future cycle ever will (throw `PersistitClosedException`).

`TransactionTest2` needs no changes: `PersistitClosedException` is already one of its expected shutdown outcomes.

### Testing

- Two new `JournalManagerTest` cases, one per window: `waitForDurabilityAfterCloseThrowsPersistitClosedException` (direct call after `close()`) and `waitForDurabilityOnStoppedFlusherThrowsInsteadOfSpinning` (via `crash()`, which stops the flusher without clearing the reference). Both verified to fail without the fix — the first with the raw `IllegalStateException`, the second by hanging past its join deadline.
- Full `persistit/core` suite on JDK 11: 592 tests, 0 failures, 0 errors, 5 skipped.
