### PR TITLE
GHSA-r7wm-3cxj-wff9 CVE-2026-54512 CVE-2026-54513 Upgrade Jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,8 @@
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
 
-        <jackson.version>2.18.6</jackson.version>
+        <!-- GHSA-r7wm-3cxj-wff9, CVE-2026-54512, CVE-2026-54513 are fixed in 2.18.8 -->
+        <jackson.version>2.18.9</jackson.version>
         <slf4j.version>2.0.17</slf4j.version>
         <swagger.version>1.6.11</swagger.version>
         <rhino.version>1.7.15.1</rhino.version>


### PR DESCRIPTION
Fixes three Jackson vulnerabilities, all patched in the 2.18.8 release:

- **GHSA-r7wm-3cxj-wff9** (`jackson-core`, CVSS 8.7) — `maxNumberLength` bypass when JSON is streamed in small chunks: up to ~20 MB of digits could accumulate before validation (memory-exhaustion DoS).
- **CVE-2026-54512** (`jackson-databind`, CVSS 8.1) — `PolymorphicTypeValidator` bypass via generic type parameters: an allowed container type can wrap a denied nested type argument (RCE-capable PoC published).
- **CVE-2026-54513** (`jackson-databind`, CVSS 8.1) — PTV bypass via `allowIfSubTypeIsArray()`: the array wrapper is allowed without validating the component type.

The `parent` BOM pins Jackson via the `jackson.version` property (currently **2.18.6**) and already imports `com.fasterxml.jackson:jackson-bom` with it, so bumping the property to **2.18.9** (the latest 2.18.x patch) fixes every downstream consumer of the BOM — no per-project overrides needed (supersedes the OpenDJ-side workaround OpenIdentityPlatform/OpenDJ#855).

Verification:
- `help:effective-pom`: managed `jackson-core`, `jackson-databind`, `jackson-annotations` all resolve to 2.18.9.
- `dependency:tree` of `commons/json-web-token`: all Jackson artifacts at 2.18.9.
- Tests of Jackson-using modules pass: `commons/util` (451 tests), `commons/json-web-token` (328 tests), zero failures.